### PR TITLE
Table ux improvements

### DIFF
--- a/src/components/common/Dropdown.jsx
+++ b/src/components/common/Dropdown.jsx
@@ -28,7 +28,7 @@ export default function Dropdown({ selected, onToggle, options }) {
          </button>
 
          {isOpen && (
-            <ul className="absolute z-10 mt-2 menu p-2 shadow bg-base-100 rounded-3xl w-52">
+            <ul className="absolute z-20 mt-2 menu p-2 shadow bg-base-100 rounded-3xl w-52">
                {options.map(option => (
                   <li key={option.value}>
                      <label className="label cursor-pointer">

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -6,7 +6,7 @@ export default function Layout() {
    return (
       <div className="site-wrapper max-w-5xl mx-auto">
          <Navbar />
-         <main className="min-h-screen flex-col items-center justify-center p-0 sm:px-2 md:p-6">
+         <main className="min-h-screen p-0 sm:px-2 md:p-6">
             <Outlet />
          </main>
       </div>

--- a/src/components/pools/PoolTable.jsx
+++ b/src/components/pools/PoolTable.jsx
@@ -41,8 +41,10 @@ export default function PoolTable({
             header: "Pool",
             meta: { showOn: "both", isSticky: true },
             cell: ({ row }) => (
-               <div className="font-medium text-base-content max-w-30">
-                  {row.original.name}
+               <div className="tooltip tooltip-right" data-tip={row.original.name}>
+                  <div className="font-medium text-base-content max-w-[120px] truncate">
+                     {row.original.name}
+                  </div>
                </div>
             )
          },
@@ -218,7 +220,7 @@ export default function PoolTable({
             key={row.id}
             ref={rowRefs[i]}
             data-pool-id={row.original.id}
-            className="hover:bg-base-300/30 transition-colors duration-150 cursor-pointer"
+            className="group hover:bg-base-300/30 transition-colors duration-150 cursor-pointer"
          >
             {row.getVisibleCells().map(cell => {
                const isSticky = cell.column.columnDef.meta?.isSticky
@@ -227,7 +229,7 @@ export default function PoolTable({
                   <td 
                      key={cell.id} 
                      className={`px-4 py-6 whitespace-nowrap text-sm
-                        ${isSticky ? "sticky left-0 bg-base-200 z-2 sticky-column-shadow" : ""}
+                        ${isSticky ? "sticky left-0 bg-base-200 group-hover:bg-base-200/20 z-2 sticky-column-shadow transition-colors duration-150" : ""}
                      `.trim()}
                   >
                      {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/src/components/pools/PoolTable.jsx
+++ b/src/components/pools/PoolTable.jsx
@@ -10,6 +10,14 @@ import PlatformIcon from "../common/PlatformIcon"
 import useBreakpoint from "../../hooks/useBreakpoint"
 import useIntersection from "../../hooks/useIntersection"
 
+/**
+ * Z-INDEX HIERARCHY:
+ * z-2:  Body cells (sticky first column)
+ * z-10: Header cells (sticky horizontal scroll)
+ * z-11: Header-body intersection (top-left corner)
+ * z-20: UI elements (dropdowns, tooltips)
+ */
+
 export default function PoolTable({ 
    pools, 
    sparklineData, 
@@ -197,8 +205,8 @@ export default function PoolTable({
                   <th
                      key={header.id}
                      onClick={header.column.getToggleSortingHandler()}
-                     className={`px-6 py-4 text-left text-xs font-semibold text-base-content/50 uppercase tracking-wider cursor-pointer hover:bg-base-300 transition
-                        ${isSticky ? "sticky left-0 bg-base-300 z-3 sticky-column-shadow" : ""}
+                     className={`sticky top-0 z-10 bg-base-300 px-6 py-4 text-left text-xs font-semibold text-base-content/50 uppercase tracking-wider cursor-pointer hover:bg-base-300 transition
+                        ${isSticky ? "left-0 z-11 sticky-column-shadow" : ""}
                      `.trim()}
                   >
                      {flexRender(header.column.columnDef.header, header.getContext())}
@@ -241,8 +249,8 @@ export default function PoolTable({
    }
 
    return (
-      <div className="overflow-x-auto scrollbar-hide">
-         <table className="min-w-full divide-y divide-base-300">
+      <div className="overflow-x-auto scrollbar-hide rounded-t-3xl max-h-[840px]">
+         <table className="min-w-full divide-y divide-base-300 border-separate border-spacing-0">
             <thead className="bg-base-300">
                {renderHeaders()}
             </thead>

--- a/src/components/pools/PoolTable.jsx
+++ b/src/components/pools/PoolTable.jsx
@@ -62,7 +62,7 @@ export default function PoolTable({
             meta: { showOn: "both" },
             cell: ({ row }) => (
                <div className="text-right text-base-content">
-                  {row.original.tvlFormatted}
+                  ${row.original.tvlFormatted}
                </div>
             )
          },
@@ -72,7 +72,7 @@ export default function PoolTable({
             meta: { showOn: "both" },
             cell: ({ row }) => (
                <div className="text-right text-base-content">
-                  {row.original.volumeFormatted}
+                  ${row.original.volumeFormatted}
                </div>
             )
          },

--- a/src/components/pools/PoolTable.jsx
+++ b/src/components/pools/PoolTable.jsx
@@ -1,4 +1,4 @@
-import { useMemo, createRef, useEffect } from "react"
+import { useMemo, createRef, useEffect, forwardRef } from "react"
 import {
    useReactTable,
    getCoreRowModel,
@@ -18,13 +18,14 @@ import useIntersection from "../../hooks/useIntersection"
  * z-20: UI elements (dropdowns, tooltips)
  */
 
-export default function PoolTable({ 
-   pools, 
-   sparklineData, 
+const PoolTable = forwardRef(({
+   pools,
+   sparklineData,
    onVisiblePoolsChange,
    sorting,
    onSortingChange
-}) {
+}, ref) => {
+
    const { isDesktop } = useBreakpoint()
 
    const rowRefs = useMemo(() => {
@@ -237,8 +238,8 @@ export default function PoolTable({
                   <td 
                      key={cell.id} 
                      className={`px-4 py-6 whitespace-nowrap text-sm
-                        ${isSticky ? "sticky left-0 bg-base-200 group-hover:bg-base-200/20 z-2 sticky-column-shadow transition-colors duration-150" : ""}
-                     `.trim()}
+                        ${isSticky ? "sticky left-0 bg-base-200 sticky-column-shadow group-hover:bg-base-200/20 z-2 transition-colors duration-150" : ""}
+                     `.trim()} // sticky-column-shadow
                   >
                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </td>
@@ -249,7 +250,10 @@ export default function PoolTable({
    }
 
    return (
-      <div className="overflow-x-auto scrollbar-hide rounded-t-3xl max-h-[840px]">
+      <div 
+         ref={ref}
+         className="overflow-x-auto scrollbar-hide rounded-t-3xl max-h-[592px] md:max-h-[840px]"
+      >
          <table className="min-w-full divide-y divide-base-300 border-separate border-spacing-0">
             <thead className="bg-base-300">
                {renderHeaders()}
@@ -260,4 +264,8 @@ export default function PoolTable({
          </table>
       </div>
    )
-}
+})
+
+PoolTable.displayName = "PoolTable"
+
+export default PoolTable

--- a/src/components/pools/PoolsContent.jsx
+++ b/src/components/pools/PoolsContent.jsx
@@ -98,7 +98,7 @@ export default function PoolsContent({
                </button>
             </div>
          ) : (
-            <div className="overflow-hidden bg-base-200 mx-0 sm:-mx-2 md:mx-0 rounded-3xl shadow-lg">
+            <div className="bg-base-200 mx-0 sm:-mx-2 md:mx-0 rounded-3xl shadow-lg">
                <PoolTable 
                   pools={paginatedPools} 
                   sparklineData={sparklineData}

--- a/src/index.css
+++ b/src/index.css
@@ -15,11 +15,10 @@
    .scrollbar-hide::-webkit-scrollbar {
       display: none;
    }
-  .sticky-column-shadow {
+   .sticky-column-shadow {
       box-shadow: 
-         /* inset -1px 0 0 0 oklch(0.2115 0.012 254.09), */
          5px 0 25px -2px rgba(0, 0, 0, 0.3);
-  }
+   }
 }
 
 @plugin "daisyui";

--- a/src/index.css
+++ b/src/index.css
@@ -17,7 +17,7 @@
    }
    .sticky-column-shadow {
       box-shadow: 
-         5px 0 25px -2px rgba(0, 0, 0, 0.3);
+         5px 0 20px -10px rgba(0, 0, 0, 0.3);
    }
 }
 

--- a/src/loaders/poolsLoader.js
+++ b/src/loaders/poolsLoader.js
@@ -4,7 +4,7 @@ function formatNumber(n) {
    if (n >= 1_000_000_000) return (n / 1_000_000_000).toFixed(1) + "B"
    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M"
    if (n >= 1_000) return (n / 1_000).toFixed(1) + "K"
-   return n.toString()
+   return n.toFixed(2)
 }
 
 const platformBranding = {


### PR DESCRIPTION
## What This PR Does

Batch of UX improvements for the pools table to make it feel more like production DeFi apps (inspired by sites like dedust.io/pools, yieldsamurai.com, orca.so/pools, defillama.com/yields).

**Main changes:**
- Sticky headers so you don't lose context when scrolling
- Sticky first column (pool names always visible on mobile)
- Better money formatting (added $ symbols, cleaned up decimals)
- Truncated long pool names with tooltips
- Auto-scroll to top when changing pages/filters

---

## Demo

**Before:**
Desktop: https://youtube.com/shorts/ggd-ppd43Fw?feature=share
Mobile: https://youtu.be/WR3RZwltEFs

**After:**
Desktop: https://youtube.com/shorts/DQ8nehBzQk0?feature=share
Mobile: https://youtu.be/zjYRmYcVe9M

Main improvements: headers stay visible, less manual scrolling, cleaner data presentation and ellipsis + tooltip in long pool names.

---

## Technical Stuff I Learned

### 1. Sticky Headers + Internal Scroll

This one took me some trial and error. My first attempt was to make headers sticky with regular body scroll, but it broke because of how CSS `position: sticky` works with overflow contexts.

**The problem:** When you have `overflow: hidden` on parent elements (which we need for horizontal scroll), `position: sticky` stops working with body scroll.

**Solution:** Created an internal scroll container with `max-h-[840px]` instead. Not as elegant as I wanted, but it works reliably and shows ~9 rows at a time which is fine for UX. Will probably fine-tune it soon.

I considered a JavaScript solution with IntersectionObserver, but decided it wasn't worth the added complexity for this use case.

**Files:** `PoolTable.jsx`, `Layout.jsx`

---

### 2. Auto-scroll on Page Change

This was actually more interesting than I expected. The goal was simple: when user clicks pagination or changes filters, scroll back to the top of the table automatically.

**Challenge:** Needed to control scroll in two places:
- The internal scroll container (inside PoolTable)
- The window scroll (to bring the table into view if user scrolled down the page)

**Solution:** Used React's `forwardRef` pattern (first time implementing it myself). This lets the parent component (PoolsContent) access the child's internal DOM element.

```javascript
// In PoolTable - expose the scroll container
const PoolTable = forwardRef((props, ref) => {
  return (
    <div ref={ref} className="overflow-x-auto max-h-[840px]">
      {/* table content */}
    </div>
  )
})
```

Then in the parent:
```javascript
const tableScrollRef = useRef(null)

useEffect(() => {
  if (tableScrollRef.current) {
    tableScrollRef.current.scrollTop = 0  // reset internal scroll
    tableScrollRef.current.scrollIntoView({ behavior: 'smooth' })  // bring into viewport
  }
}, [pageIndex])
```

**Gotcha I ran into:** The useEffect was triggering on initial mount, causing an unnecessary scroll animation on page load. Fixed it with a "skip first render" pattern using `useRef(true)` as a flag.

**Files:** `PoolsContent.jsx`, `PoolTable.jsx`

---

### 3. Sticky First Column

Pretty straightforward - added `position: sticky` + `left-0` to the first column so pool names don't disappear during horizontal scroll on mobile.

Added a custom box-shadow to give it some depth so it doesn't look flat against the other columns. I'm not completely satisfied with the shadow. It works but I will probably visually enhance/polish it in the near future.

Had to be careful with z-index to make sure headers, body cells, and the sticky column all layered correctly:
- Body cells: `z-2`
- Headers: `z-10`  
- Corner intersection: `z-11`

**Files:** `PoolTable.jsx`

---

### 4. Money Formatting

Small but noticeable improvement - added `$` symbols and cleaned up decimals:
- Values over $1M: keep abbreviated (e.g., "$1.2M")
- Values under $1M: truncate to 2 decimals instead of showing 6+ decimal places

Makes the numbers way easier to scan.

**Files:** `poolsLoader.js`

---

### 5. Long Pool Names

Some pool names are 30+ characters and were breaking the layout on mobile. Added `max-w-[120px]` with truncation and wrapped in a tooltip so you can still see the full name on hover.

Not perfect (tooltips on mobile aren't great), but better than the alternative of having inconsistent row heights.

**Files:** `PoolTable.jsx`

---

## What I'd Improve Next

- Add support for `prefers-reduced-motion` (right now it ignores user accessibility settings)
- The tooltip solution for long names isn't ideal on mobile - might explore other options
- Could make the z-index values configurable instead of hardcoded

---

## Testing

Tested on:
- Chrome, Firefox, Safari (latest versions)
- Mobile viewport (450px), tablet (768px), desktop (1024px+)
- All scroll behaviors work as expected
- No console errors or visual glitches

---

## Files Changed

- `PoolsContent.jsx` - Added dual-ref system for scroll control
- `PoolTable.jsx` - Converted to forwardRef, added sticky positioning
- `poolsLoader.js` - Updated money formatting logic
- `Layout.jsx` - Cleaned up unnecessary flex classes

---

**Merge strategy:** Planning to use merge commit to preserve individual commits (want to show the incremental progress for portfolio purposes).