### PR TITLE
Feat/range calculator

### DIFF
--- a/src/components/pool-detail/CalculatorInputs.jsx
+++ b/src/components/pool-detail/CalculatorInputs.jsx
@@ -3,63 +3,64 @@ export function CalculatorInputs({
    onChange,
    onIncrement,
    onPresetClick,
-   currentPrice,
    priceLabel,
    token0Symbol, 
    token1Symbol,
    token0PriceUSD,
-   token1PriceUSD
+   token1PriceUSD,
+   composition
 }) {
-   const priceNum = Number(currentPrice)
-      
-   // Token amounts based on 50/50 split
-   const token0Amount = token0PriceUSD > 0
-      ? (inputs.capitalUSD / 2) / token0PriceUSD
-      : 0
+   // Token amounts based on composition, fallback to 50/50
+   const token0Amount = composition?.amount0 ?? (
+      token0PriceUSD > 0 ? (inputs.capitalUSD / 2) / token0PriceUSD : 0
+   )
 
-   const token1Amount = token1PriceUSD > 0
-      ? (inputs.capitalUSD / 2) / token1PriceUSD
-      : 0
+   const token1Amount = composition?.amount1 ?? (
+      token1PriceUSD > 0 ? (inputs.capitalUSD / 2) / token1PriceUSD : 0
+   )
+
+   const capital0 = composition?.capital0USD ?? (inputs.capitalUSD / 2)
+   const capital1 = composition?.capital1USD ?? (inputs.capitalUSD / 2)
 
    return (
       <div>
          {/* Deposit Amount */}
          <div className="mb-6">
-         <label className="block text-sm font-semibold mb-2">Deposit Amount</label>
-         <div className="relative">
-            <span className="absolute left-4 top-1/2 -translate-y-1/2 text-2xl text-base-content/60">$</span>
-            <input
-               type="number"
-               value={inputs.capitalUSD}
-               onChange={(e) => onChange('capitalUSD', Number(e.target.value))}
-               className="input input-lg w-full pl-10 text-2xl font-bold bg-base-300"
-               min="0"
-            />
-         </div>
+            <label className="block text-sm font-semibold mb-2">Deposit Amount</label>
+            <div className="relative">
+               <input
+                  type="number"
+                  value={inputs.capitalUSD}
+                  onChange={(e) => onChange('capitalUSD', Number(e.target.value))}
+                  className="input input-xl w-full pl-10 text-3xl font-bold bg-base-300"
+                  min="0"
+               />
+               <span className="absolute left-4 top-1/2 -translate-y-1/2 text-3xl text-base-content/60">$</span>
+            </div>
 
-         {/* Token breakdown */}
-         <div className="mt-3 space-y-2">
-            <div className="flex items-center justify-between text-sm">
-               <span className="flex items-center gap-2">
-                  <span className="w-2 h-2 rounded-full bg-primary"></span>
-                  {token0Symbol}:
-               </span>
-               <span>
-                  {token0Amount > 0 ? token0Amount.toFixed(5) : "N/A"} 
-                  <span className="text-base-content/60 ml-2">${(inputs.capitalUSD / 2).toFixed(2)}</span>
-               </span>
+            {/* Token breakdown */}
+            <div className="mt-3 space-y-2">
+               <div className="flex items-center justify-between text-sm">
+                  <span className="flex items-center gap-2">
+                     <span className="w-2 h-2 rounded-full bg-primary"></span>
+                     {token0Symbol}:
+                  </span>
+                  <span>
+                     {token0Amount > 0 ? token0Amount.toFixed(6) : "--"} 
+                     <span className="text-base-content/60 ml-2">${capital0.toFixed(2)}</span>
+                  </span>
+               </div>
+               <div className="flex items-center justify-between text-sm">
+                  <span className="flex items-center gap-2">
+                     <span className="w-2 h-2 rounded-full bg-secondary"></span>
+                     {token1Symbol}:
+                  </span>
+                  <span>
+                     {token1Amount > 0 ? token1Amount.toFixed(6) : "--"}
+                     <span className="text-base-content/60 ml-2">${capital1.toFixed(2)}</span>
+                  </span>
+               </div>
             </div>
-            <div className="flex items-center justify-between text-sm">
-               <span className="flex items-center gap-2">
-                  <span className="w-2 h-2 rounded-full bg-secondary"></span>
-                  {token1Symbol}:
-               </span>
-               <span>
-                  {token1Amount > 0 ? token1Amount.toFixed(5) : "N/A"}
-                  <span className="text-base-content/60 ml-2">${(inputs.capitalUSD / 2).toFixed(2)}</span>
-               </span>
-            </div>
-         </div>
          </div>
 
          {/* Price Range */}
@@ -106,7 +107,7 @@ export function CalculatorInputs({
 
             {/* Min/Max inputs (disabled if fullRange) */}
             <div className="grid grid-cols-2 gap-3 mb-3">
-               <div>
+               <div className="form-control bg-base-300 rounded-lg p-3">
                   <div className="flex justify-between items-center mb-1">
                      <label className="text-xs text-base-content/60">Min Price</label>
                      <div className="flex gap-1">
@@ -136,19 +137,19 @@ export function CalculatorInputs({
                      onChange={(e) => onChange('minPrice', e.target.value)}
                      disabled={inputs.fullRange}
                      placeholder="0"
-                     className="input input-sm w-full bg-base-300"
+                     className="input input-md w-full text-lg text-center bg-base-300"
                      step="0.0001"
                   />
-                  <p className="text-xs text-base-content/50 mt-1">{priceLabel}</p>
+                  <p className="text-xs text-center text-base-content/50 mt-2">{priceLabel}</p>
                </div>
                
-               <div>
+               <div className="form-control bg-base-300 rounded-lg p-3">
                   <div className="flex justify-between items-center mb-1">
                      <label className="text-xs text-base-content/60">Max Price</label>
                      <div className="flex gap-1">
                         <button
                            type="button"
-                           onClick={() => onIncrement('maxPrice', -1)}
+                           onClick={() => onIncrement("maxPrice", -1)}
                            disabled={inputs.fullRange}
                            className="btn btn-xs btn-circle btn-ghost"
                            title="Decrease by 1 tick spacing"
@@ -157,7 +158,7 @@ export function CalculatorInputs({
                         </button>
                         <button
                            type="button"
-                           onClick={() => onIncrement('maxPrice', 1)}
+                           onClick={() => onIncrement("maxPrice", 1)}
                            disabled={inputs.fullRange}
                            className="btn btn-xs btn-circle btn-ghost"
                            title="Increase by 1 tick spacing"
@@ -169,24 +170,60 @@ export function CalculatorInputs({
                   <input
                      type="number"
                      value={inputs.fullRange ? "" : inputs.maxPrice}
-                     onChange={(e) => onChange('maxPrice', e.target.value)}
+                     onChange={(e) => onChange("maxPrice", e.target.value)}
                      disabled={inputs.fullRange}
                      placeholder="∞"
-                     className="input input-sm w-full bg-base-300"
+                     className="input input-md w-full text-lg text-center bg-base-300"
                      step="0.0001"
                   />
-                  <p className="text-xs text-base-content/50 mt-1">{priceLabel}</p>
+                  <p className="text-xs text-center text-base-content/50 mt-2">{priceLabel}</p>
                </div>
             </div>
 
             {/* Most Active Price - use priceNum */}
             <div className="bg-base-300 rounded-lg p-3">
-               <div className="flex justify-between items-center mb-2">
-                  <span className="text-xs text-base-content/60">Most Active Price Assumption</span>
-                  <button className="btn btn-circle btn-xs">?</button>
+               <div className="flex justify-between items-center mb-2 gap-2">
+                  <div className="flex items-center">
+                     <span className="text-xs text-base-content/60 pr-2">Assumed Entry Price</span>
+                     <button className="btn btn-circle btn-xs">
+                        <div 
+                           className="tooltip tooltip-right" 
+                           data-tip="It first populates with the most recent price for the pool. You can adjust your desired entry price for the range calculator."
+                        >
+                           <div className="font-medium text-base-content max-w-[120px] truncate">
+                              ?
+                           </div>
+                        </div>
+                     </button>
+                  </div>
+                  <div className="flex items-center">
+                     <button 
+                        type="button"
+                        onClick={() => onIncrement("assumedPrice", - 1)}
+                        className="btn btn-xs btn-circle btn-ghost"
+                        title="Decrease by 1 tick spacing"
+                     >
+                        −
+                     </button>
+                     <button 
+                        type="button"
+                        onClick={() => onIncrement("assumedPrice", 1)}
+                        className="btn btn-xs btn-circle btn-ghost"
+                        title="Increase by 1 tick spacing"
+                     >
+                        +
+                     </button>
+                  </div>
                </div>
-               <p className="text-sm font-mono">{priceNum.toFixed(8)}</p>
-               <p className="text-xs text-base-content/50">{priceLabel}</p>
+               <input 
+                  type="number"
+                  value={inputs.fullRange ? "" : inputs.assumedPrice}
+                  onChange={(e) => onChange('assumedPrice', Number(e.target.value))}
+                  disabled={inputs.fullRange}
+                  placeholder={inputs.fullRange ? "50/50 split" : ""}
+                  className="input input-md w-full text-lg text-center bg-base-300"
+               />
+               <p className="text-xs text-center text-base-content/50 mt-2">{priceLabel}</p>
             </div>
          </div>
 

--- a/src/components/pool-detail/CalculatorInputs.jsx
+++ b/src/components/pool-detail/CalculatorInputs.jsx
@@ -1,13 +1,15 @@
 export function CalculatorInputs({ 
    inputs, 
-   onChange, 
+   onChange,
+   onIncrement,
+   onPresetClick,
    currentPrice,
    priceLabel,
    token0Symbol, 
    token1Symbol,
    token0PriceUSD,
    token1PriceUSD
-   }) {
+}) {
    const priceNum = Number(currentPrice)
       
    // Token amounts based on 50/50 split
@@ -39,22 +41,22 @@ export function CalculatorInputs({
          <div className="mt-3 space-y-2">
             <div className="flex items-center justify-between text-sm">
                <span className="flex items-center gap-2">
-               <span className="w-2 h-2 rounded-full bg-primary"></span>
-               {token0Symbol}:
+                  <span className="w-2 h-2 rounded-full bg-primary"></span>
+                  {token0Symbol}:
                </span>
                <span>
-               {token0Amount > 0 ? token0Amount.toFixed(5) : "N/A"} 
-               <span className="text-base-content/60 ml-2">${(inputs.capitalUSD / 2).toFixed(2)}</span>
+                  {token0Amount > 0 ? token0Amount.toFixed(5) : "N/A"} 
+                  <span className="text-base-content/60 ml-2">${(inputs.capitalUSD / 2).toFixed(2)}</span>
                </span>
             </div>
             <div className="flex items-center justify-between text-sm">
                <span className="flex items-center gap-2">
-               <span className="w-2 h-2 rounded-full bg-secondary"></span>
-               {token1Symbol}:
+                  <span className="w-2 h-2 rounded-full bg-secondary"></span>
+                  {token1Symbol}:
                </span>
                <span>
-               {token1Amount > 0 ? token1Amount.toFixed(5) : "N/A"}
-               <span className="text-base-content/60 ml-2">${(inputs.capitalUSD / 2).toFixed(2)}</span>
+                  {token1Amount > 0 ? token1Amount.toFixed(5) : "N/A"}
+                  <span className="text-base-content/60 ml-2">${(inputs.capitalUSD / 2).toFixed(2)}</span>
                </span>
             </div>
          </div>
@@ -62,62 +64,130 @@ export function CalculatorInputs({
 
          {/* Price Range */}
          <div className="mb-6">
-         <div className="flex justify-between items-center mb-2">
-            <label className="text-sm font-semibold">Price Range</label>
-            <label className="flex items-center gap-2 cursor-pointer">
-               <span className="text-sm">Full Range:</span>
-               <input
-               type="checkbox"
-               checked={inputs.fullRange}
-               onChange={(e) => onChange('fullRange', e.target.checked)}
-               className="toggle toggle-sm"
-               />
-            </label>
-         </div>
-
-         {/* Min/Max inputs (disabled if fullRange) */}
-         <div className="grid grid-cols-2 gap-3 mb-3">
-            <div>
-               <label className="block text-xs text-base-content/60 mb-1">Min Price</label>
-               <input
-                  type="number"
-                  value={inputs.minPrice}
-                  onChange={(e) => onChange('minPrice', e.target.value)}
-                  disabled={inputs.fullRange}
-                  placeholder="0"
-                  className="input input-sm w-full bg-base-300"
-                  step="0.0001"
-               />
-               <p className="text-xs text-base-content/50 mt-1">
-                  {priceLabel}
-               </p>
-            </div>
-            <div>
-               <label className="block text-xs text-base-content/60 mb-1">Max Price</label>
-               <input
-                  type="number"
-                  value={inputs.maxPrice}
-                  onChange={(e) => onChange('maxPrice', e.target.value)}
-                  disabled={inputs.fullRange}
-                  placeholder="∞"
-                  className="input input-sm w-full bg-base-300"
-                  step="0.0001"
-               />
-               <p className="text-xs text-base-content/50 mt-1">
-                  {priceLabel}
-               </p>
-            </div>
-         </div>
-
-         {/* Most Active Price - usar priceNum */}
-         <div className="bg-base-300 rounded-lg p-3">
             <div className="flex justify-between items-center mb-2">
-               <span className="text-xs text-base-content/60">Most Active Price Assumption</span>
-               <button className="btn btn-circle btn-xs">?</button>
+               <label className="text-sm font-semibold">Price Range</label>
+               <label className="flex items-center gap-2 cursor-pointer">
+                  <span className="text-sm">Full Range:</span>
+                  <input
+                     type="checkbox"
+                     checked={inputs.fullRange}
+                     onChange={(e) => onChange('fullRange', e.target.checked)}
+                     className="toggle toggle-sm"
+                  />
+               </label>
             </div>
-            <p className="text-sm font-mono">{priceNum.toFixed(8)}</p>
-            <p className="text-xs text-base-content/50">{priceLabel}</p>
-         </div>
+
+            <div className="flex gap-2 mb-3">
+               <button
+                  type="button"
+                  onClick={() => onPresetClick("±10%")}
+                  className="btn btn-sm btn-outline flex-1"
+                  disabled={inputs.fullRange}
+               >
+                  ±10%
+               </button>
+               <button
+                  type="button"
+                  onClick={() => onPresetClick("±15%")}
+                  className="btn btn-sm btn-outline flex-1"
+                  disabled={inputs.fullRange}
+               >
+                  ±15%
+               </button>
+               <button
+                  type="button"
+                  onClick={() => onPresetClick("±20%")}
+                  className="btn btn-sm btn-outline flex-1"
+                  disabled={inputs.fullRange}
+               >
+                  ±20%
+               </button>
+            </div>
+
+            {/* Min/Max inputs (disabled if fullRange) */}
+            <div className="grid grid-cols-2 gap-3 mb-3">
+               <div>
+                  <div className="flex justify-between items-center mb-1">
+                     <label className="text-xs text-base-content/60">Min Price</label>
+                     <div className="flex gap-1">
+                        <button
+                           type="button"
+                           onClick={() => onIncrement('minPrice', -1)}
+                           disabled={inputs.fullRange}
+                           className="btn btn-xs btn-circle btn-ghost"
+                           title="Decrease by 1 tick spacing"
+                        >
+                           −
+                        </button>
+                        <button
+                           type="button"
+                           onClick={() => onIncrement('minPrice', 1)}
+                           disabled={inputs.fullRange}
+                           className="btn btn-xs btn-circle btn-ghost"
+                           title="Increase by 1 tick spacing"
+                        >
+                           +
+                        </button>
+                     </div>
+                  </div>
+                  <input
+                     type="number"
+                     value={inputs.fullRange ? "" : inputs.minPrice}
+                     onChange={(e) => onChange('minPrice', e.target.value)}
+                     disabled={inputs.fullRange}
+                     placeholder="0"
+                     className="input input-sm w-full bg-base-300"
+                     step="0.0001"
+                  />
+                  <p className="text-xs text-base-content/50 mt-1">{priceLabel}</p>
+               </div>
+               
+               <div>
+                  <div className="flex justify-between items-center mb-1">
+                     <label className="text-xs text-base-content/60">Max Price</label>
+                     <div className="flex gap-1">
+                        <button
+                           type="button"
+                           onClick={() => onIncrement('maxPrice', -1)}
+                           disabled={inputs.fullRange}
+                           className="btn btn-xs btn-circle btn-ghost"
+                           title="Decrease by 1 tick spacing"
+                        >
+                           −
+                        </button>
+                        <button
+                           type="button"
+                           onClick={() => onIncrement('maxPrice', 1)}
+                           disabled={inputs.fullRange}
+                           className="btn btn-xs btn-circle btn-ghost"
+                           title="Increase by 1 tick spacing"
+                        >
+                           +
+                        </button>
+                     </div>
+                  </div>
+                  <input
+                     type="number"
+                     value={inputs.fullRange ? "" : inputs.maxPrice}
+                     onChange={(e) => onChange('maxPrice', e.target.value)}
+                     disabled={inputs.fullRange}
+                     placeholder="∞"
+                     className="input input-sm w-full bg-base-300"
+                     step="0.0001"
+                  />
+                  <p className="text-xs text-base-content/50 mt-1">{priceLabel}</p>
+               </div>
+            </div>
+
+            {/* Most Active Price - use priceNum */}
+            <div className="bg-base-300 rounded-lg p-3">
+               <div className="flex justify-between items-center mb-2">
+                  <span className="text-xs text-base-content/60">Most Active Price Assumption</span>
+                  <button className="btn btn-circle btn-xs">?</button>
+               </div>
+               <p className="text-sm font-mono">{priceNum.toFixed(8)}</p>
+               <p className="text-xs text-base-content/50">{priceLabel}</p>
+            </div>
          </div>
 
          {/* Create Position Button */}

--- a/src/components/pool-detail/CalculatorInputs.jsx
+++ b/src/components/pool-detail/CalculatorInputs.jsx
@@ -1,0 +1,129 @@
+export function CalculatorInputs({ 
+   inputs, 
+   onChange, 
+   currentPrice,
+   priceLabel,
+   token0Symbol, 
+   token1Symbol,
+   token0PriceUSD,
+   token1PriceUSD
+   }) {
+   const priceNum = Number(currentPrice)
+      
+   // Token amounts based on 50/50 split
+   const token0Amount = token0PriceUSD > 0
+      ? (inputs.capitalUSD / 2) / token0PriceUSD
+      : 0
+
+   const token1Amount = token1PriceUSD > 0
+      ? (inputs.capitalUSD / 2) / token1PriceUSD
+      : 0
+
+   return (
+      <div>
+         {/* Deposit Amount */}
+         <div className="mb-6">
+         <label className="block text-sm font-semibold mb-2">Deposit Amount</label>
+         <div className="relative">
+            <span className="absolute left-4 top-1/2 -translate-y-1/2 text-2xl text-base-content/60">$</span>
+            <input
+               type="number"
+               value={inputs.capitalUSD}
+               onChange={(e) => onChange('capitalUSD', Number(e.target.value))}
+               className="input input-lg w-full pl-10 text-2xl font-bold bg-base-300"
+               min="0"
+            />
+         </div>
+
+         {/* Token breakdown */}
+         <div className="mt-3 space-y-2">
+            <div className="flex items-center justify-between text-sm">
+               <span className="flex items-center gap-2">
+               <span className="w-2 h-2 rounded-full bg-primary"></span>
+               {token0Symbol}:
+               </span>
+               <span>
+               {token0Amount > 0 ? token0Amount.toFixed(5) : "N/A"} 
+               <span className="text-base-content/60 ml-2">${(inputs.capitalUSD / 2).toFixed(2)}</span>
+               </span>
+            </div>
+            <div className="flex items-center justify-between text-sm">
+               <span className="flex items-center gap-2">
+               <span className="w-2 h-2 rounded-full bg-secondary"></span>
+               {token1Symbol}:
+               </span>
+               <span>
+               {token1Amount > 0 ? token1Amount.toFixed(5) : "N/A"}
+               <span className="text-base-content/60 ml-2">${(inputs.capitalUSD / 2).toFixed(2)}</span>
+               </span>
+            </div>
+         </div>
+         </div>
+
+         {/* Price Range */}
+         <div className="mb-6">
+         <div className="flex justify-between items-center mb-2">
+            <label className="text-sm font-semibold">Price Range</label>
+            <label className="flex items-center gap-2 cursor-pointer">
+               <span className="text-sm">Full Range:</span>
+               <input
+               type="checkbox"
+               checked={inputs.fullRange}
+               onChange={(e) => onChange('fullRange', e.target.checked)}
+               className="toggle toggle-sm"
+               />
+            </label>
+         </div>
+
+         {/* Min/Max inputs (disabled if fullRange) */}
+         <div className="grid grid-cols-2 gap-3 mb-3">
+            <div>
+               <label className="block text-xs text-base-content/60 mb-1">Min Price</label>
+               <input
+                  type="number"
+                  value={inputs.minPrice}
+                  onChange={(e) => onChange('minPrice', e.target.value)}
+                  disabled={inputs.fullRange}
+                  placeholder="0"
+                  className="input input-sm w-full bg-base-300"
+                  step="0.0001"
+               />
+               <p className="text-xs text-base-content/50 mt-1">
+                  {priceLabel}
+               </p>
+            </div>
+            <div>
+               <label className="block text-xs text-base-content/60 mb-1">Max Price</label>
+               <input
+                  type="number"
+                  value={inputs.maxPrice}
+                  onChange={(e) => onChange('maxPrice', e.target.value)}
+                  disabled={inputs.fullRange}
+                  placeholder="∞"
+                  className="input input-sm w-full bg-base-300"
+                  step="0.0001"
+               />
+               <p className="text-xs text-base-content/50 mt-1">
+                  {priceLabel}
+               </p>
+            </div>
+         </div>
+
+         {/* Most Active Price - usar priceNum */}
+         <div className="bg-base-300 rounded-lg p-3">
+            <div className="flex justify-between items-center mb-2">
+               <span className="text-xs text-base-content/60">Most Active Price Assumption</span>
+               <button className="btn btn-circle btn-xs">?</button>
+            </div>
+            <p className="text-sm font-mono">{priceNum.toFixed(8)}</p>
+            <p className="text-xs text-base-content/50">{priceLabel}</p>
+         </div>
+         </div>
+
+         {/* Create Position Button */}
+         <button className="btn btn-primary w-full">
+            Create Position on Uniswap →
+         </button>
+      </div>
+   )
+}

--- a/src/components/pool-detail/CalculatorStats.jsx
+++ b/src/components/pool-detail/CalculatorStats.jsx
@@ -1,0 +1,82 @@
+export function CalculatorStats({ results, loading, fetchError }) {
+   // Error de fetch (TheGraph falló)
+   if (fetchError) {
+      return (
+         <div className="mb-6">
+            <p className="text-error text-sm">Failed to load pool data: {fetchError}</p>
+         </div>
+      )
+   }
+
+   // Loading (hourlyData aún no cargó)
+   if (loading || results === null) {
+      return (
+         <div className="mb-6">
+            <h3 className="text-lg font-semibold mb-2">Estimated Fees (24h)</h3>
+            <div className="text-4xl font-bold text-success mb-4 animate-pulse">$--</div>
+            <div className="space-y-2">
+               <div className="flex justify-between animate-pulse">
+                  <span className="text-base-content/60">MONTHLY:</span>
+                  <span>$-- --%</span>
+               </div>
+               <div className="flex justify-between animate-pulse">
+                  <span className="text-base-content/60">YEARLY (APR):</span>
+                  <span>$-- --%</span>
+               </div>
+            </div>
+         </div>
+      )
+   }
+
+   // Error de simulación (invalid range)
+   if (!results.success) {
+      return (
+         <div className="mb-6">
+            <h3 className="text-lg font-semibold mb-2">Estimated Fees (24h)</h3>
+            <p className="text-error text-sm">{results.error}</p>
+         </div>
+      )
+   }
+
+   {results.dataQuality === "LIMITED" && (
+      <div className="alert alert-warning mb-4">
+         <span>⚠️ Limited historical data. APR estimate may be less accurate.</span>
+      </div>
+   )}
+
+   // Success: mostrar stats
+   const dailyFees = results.totalFeesUSD / 7 // 7 días de histórico
+   const monthlyFees = dailyFees * 30
+   const yearlyFees = dailyFees * 365
+   const yearlyAPR = results.APR
+   const monthlyAPR = yearlyAPR / 12
+
+   return (
+      <div className="mb-6">
+         <h3 className="text-lg font-semibold mb-2">Estimated Fees (24h)</h3>
+         <div className="text-4xl font-bold text-success mb-4">
+            ${dailyFees.toFixed(2)}
+         </div>
+         
+         <div className="space-y-2 mb-4">
+            <div className="flex justify-between">
+               <span className="text-base-content/60">MONTHLY:</span>
+               <span className="font-semibold">
+                  ${monthlyFees.toFixed(2)} <span className="text-success">{monthlyAPR.toFixed(2)}%</span>
+               </span>
+            </div>
+            <div className="flex justify-between">
+               <span className="text-base-content/60">YEARLY (APR):</span>
+               <span className="font-semibold">
+                  ${yearlyFees.toFixed(2)} <span className="text-success">{yearlyAPR.toFixed(2)}%</span>
+               </span>
+            </div>
+         </div>
+
+         <div className="flex gap-2">
+            <button className="btn btn-sm btn-outline flex-1">Compare Pools</button>
+            <button className="btn btn-sm btn-outline flex-1">Calculate IL</button>
+         </div>
+      </div>
+   )
+}

--- a/src/components/pool-detail/CalculatorStats.jsx
+++ b/src/components/pool-detail/CalculatorStats.jsx
@@ -1,4 +1,15 @@
-export function CalculatorStats({ results, loading, fetchError }) {
+import { useState } from "react"
+import { ILProjectionModal } from "./ILProjectionModal"
+
+export function CalculatorStats({ 
+   results, 
+   isLoading, 
+   fetchError,
+   poolData,
+   rangeInputs
+}) {
+   const [isModalOpen, setIsModalOpen] = useState(false)
+
    // Error de fetch (TheGraph falló)
    if (fetchError) {
       return (
@@ -9,7 +20,7 @@ export function CalculatorStats({ results, loading, fetchError }) {
    }
 
    // Loading (hourlyData aún no cargó)
-   if (loading || results === null) {
+   if (isLoading || results === null) {
       return (
          <div className="mb-6">
             <h3 className="text-lg font-semibold mb-2">Estimated Fees (24h)</h3>
@@ -49,38 +60,54 @@ export function CalculatorStats({ results, loading, fetchError }) {
    const hasLimitedData = results.daysOfData < 7
 
    return (
-      <div className="mb-6">
-         <h3 className="text-lg font-semibold mb-2">Estimated Fees (24h)</h3>
-         <div className="text-4xl font-bold text-success mb-4">
-            ${dailyFees.toFixed(2)}
-         </div>
-         
-         <div className="space-y-2 mb-4">
-            <div className="flex justify-between">
-               <span className="text-base-content/60">MONTHLY:</span>
-               <span className="font-semibold">
-                  ${monthlyFees.toFixed(2)} <span className="text-success">{monthlyAPR.toFixed(2)}%</span>
-               </span>
+      <>
+         <div className="mb-6">
+            <h3 className="text-lg font-semibold mb-2">Estimated Fees (24h)</h3>
+            <div className="text-4xl font-bold text-success mb-4">
+               ${dailyFees.toFixed(2)}
             </div>
-            <div className="flex justify-between">
-               <span className="text-base-content/60">YEARLY (APR):</span>
-               <span className="font-semibold">
-                  ${yearlyFees.toFixed(2)} <span className="text-success">{yearlyAPR.toFixed(2)}%</span>
-               </span>
+            
+            <div className="space-y-2 mb-4">
+               <div className="flex justify-between">
+                  <span className="text-base-content/60">MONTHLY:</span>
+                  <span className="font-semibold">
+                     ${monthlyFees.toFixed(2)} <span className="text-success">{monthlyAPR.toFixed(2)}%</span>
+                  </span>
+               </div>
+               <div className="flex justify-between">
+                  <span className="text-base-content/60">YEARLY (APR):</span>
+                  <span className="font-semibold">
+                     ${yearlyFees.toFixed(2)} <span className="text-success">{yearlyAPR.toFixed(2)}%</span>
+                  </span>
+               </div>
+            </div>
+
+            {/* Data Quality Warning */}
+            {hasLimitedData && (
+               <div className="alert alert-warning text-xs mb-4">
+                  ⚠️ Based on {results.daysOfData.toFixed(1)} days. Projections may be vary.
+               </div>
+            )}
+
+            <div className="flex gap-2">
+               <button className="btn btn-sm btn-outline">Compare Pools</button>
+               <button
+                  onClick={() => setIsModalOpen(true)}
+                  className="btn btn-sm btn-outline flex-1"
+               >
+                  Simulate Position Performance
+               </button>
             </div>
          </div>
 
-         {/* Data Quality Warning */}
-         {hasLimitedData && (
-            <div className="alert alert-warning text-xs mb-4">
-               ⚠️ Based on {results.daysOfData.toFixed(1)} days. Projections may be vary.
-            </div>
-         )}
-
-         <div className="flex gap-2">
-            <button className="btn btn-sm btn-outline flex-1">Compare Pools</button>
-            <button className="btn btn-sm btn-outline flex-1">Calculate IL</button>
-         </div>
-      </div>
+         {/* Simulate Position Performance Modal */}
+         <ILProjectionModal 
+            isOpen={isModalOpen}
+            onClose={() => setIsModalOpen(false)}
+            poolData={poolData}
+            rangeInputs={rangeInputs}
+            results={results}
+         />
+      </>
    )
 }

--- a/src/components/pool-detail/CalculatorStats.jsx
+++ b/src/components/pool-detail/CalculatorStats.jsx
@@ -38,18 +38,15 @@ export function CalculatorStats({ results, loading, fetchError }) {
       )
    }
 
-   {results.dataQuality === "LIMITED" && (
-      <div className="alert alert-warning mb-4">
-         <span>⚠️ Limited historical data. APR estimate may be less accurate.</span>
-      </div>
-   )}
-
    // Success: mostrar stats
-   const dailyFees = results.totalFeesUSD / 7 // 7 días de histórico
+   const dailyFees = results.dailyFeesUSD // From simulation
    const monthlyFees = dailyFees * 30
    const yearlyFees = dailyFees * 365
    const yearlyAPR = results.APR
    const monthlyAPR = yearlyAPR / 12
+
+   // Data quality disclaimer
+   const hasLimitedData = results.daysOfData < 7
 
    return (
       <div className="mb-6">
@@ -72,6 +69,13 @@ export function CalculatorStats({ results, loading, fetchError }) {
                </span>
             </div>
          </div>
+
+         {/* Data Quality Warning */}
+         {hasLimitedData && (
+            <div className="alert alert-warning text-xs mb-4">
+               ⚠️ Based on {results.daysOfData.toFixed(1)} days. Projections may be vary.
+            </div>
+         )}
 
          <div className="flex gap-2">
             <button className="btn btn-sm btn-outline flex-1">Compare Pools</button>

--- a/src/components/pool-detail/ILProjectionModal.jsx
+++ b/src/components/pool-detail/ILProjectionModal.jsx
@@ -1,0 +1,77 @@
+import { PriceInputSection } from "./PriceInputSection"
+import { TimeLineControl } from "./TimeLineControl"
+import { StrategyComparison } from "./StrategyComparison"
+import { useProjectionCalculator } from "../../hooks/useProjectionCalculator"
+
+export function ILProjectionModal({
+   isOpen,
+   onClose,
+   poolData,
+   rangeInputs,
+   results
+}) {
+   const {
+      hodlStrategy,
+      lpStrategy,
+      isCalculating,
+      currentToken0PriceUSD,
+      currentToken1PriceUSD,
+      futureToken0Price,
+      futureToken1Price,
+      projectionDays,
+      setFutureToken0Price,
+      setFutureToken1Price,
+      setProjectionDays,
+      daysToBreakEven
+   } = useProjectionCalculator(poolData, rangeInputs, results)
+
+   return (
+      <dialog className={`modal ${isOpen ? "modal-open" : ""}`}>
+         <div className="modal-box max-w-xl bg-base-200">
+            {/* Header */}
+            <div className="flex justify-between items-center mb-6">
+               <h3 className="text-2xl font-bold">Simulate Position Performance</h3>
+               <button 
+                  onClick={onClose}
+                  className="btn btn-sm btn-circle btn-ghost"
+               >
+                  x
+               </button>
+            </div>
+
+            {/* Content */}
+            <StrategyComparison 
+               hodlStrategy={hodlStrategy}
+               lpStrategy={lpStrategy}
+               isCalculating={isCalculating}
+            />
+
+            {/* User inputs */}
+            <div className="space-y-6">
+               <PriceInputSection 
+                  token0Symbol={poolData.token0.symbol}
+                  token1Symbol={poolData.token1.symbol}
+                  currentToken0PriceUSD={currentToken0PriceUSD}
+                  currentToken1PriceUSD={currentToken1PriceUSD}
+                  futureToken0PriceUSD={futureToken0Price}
+                  futureToken1PriceUSD={futureToken1Price}
+                  onToken0PriceChange={setFutureToken0Price}
+                  onToken1PriceChange={setFutureToken1Price}
+               />
+               <TimeLineControl 
+                  days={projectionDays}
+                  onDaysChange={setProjectionDays}
+                  daysToBreakEven={daysToBreakEven}
+               />
+            </div>
+         </div>
+         <form 
+            method="dialog"
+            onClick={onClose}
+            className="modal-backdrop"
+         >
+            <button>close</button>
+         </form>
+      </dialog>
+   )
+}

--- a/src/components/pool-detail/PoolCharts.jsx
+++ b/src/components/pool-detail/PoolCharts.jsx
@@ -12,8 +12,7 @@ export function PoolCharts({ history, selectedTokenIdx, tokenSymbols }) {
    }
 
    return (
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-         <h2>Calculator component will go here</h2>
+      <div className="grid grid-cols-1 gap-4">
          <PriceChart 
             history={history} 
             selectedTokenIdx={selectedTokenIdx} 

--- a/src/components/pool-detail/PoolCharts.jsx
+++ b/src/components/pool-detail/PoolCharts.jsx
@@ -2,7 +2,13 @@ import { TVLVolumeChart } from "./TVLVolumeChart"
 import { PriceChart } from "./PriceChart"
 import { FeesApyChart } from "./FeesApyChart"
 
-export function PoolCharts({ history, selectedTokenIdx, tokenSymbols }) {
+export function PoolCharts({ 
+   history, 
+   selectedTokenIdx, 
+   tokenSymbols,
+   rangeInputs,
+   currentPrice
+}) {
    if (!history || history.length === 0) {
       return (
          <div className="card bg-base-200 rounded-2xl p-8 text-center">
@@ -17,6 +23,8 @@ export function PoolCharts({ history, selectedTokenIdx, tokenSymbols }) {
             history={history} 
             selectedTokenIdx={selectedTokenIdx} 
             tokenSymbols={tokenSymbols}
+            rangeInputs={rangeInputs}
+            currentPrice={currentPrice}
          />
          <TVLVolumeChart history={history} />
          <FeesApyChart history={history} />

--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -8,10 +8,11 @@ export default function PoolDetail() {
    const { pool, history } = useLoaderData()
    const [selectedTokenIdx, setSelectedTokenIdx] = useState(0)
    const [rangeInputs, setRangeInputs] = useState({
+      capitalUSD: 1000,
+      fullRange: false,
       minPrice: null,
       maxPrice: null,
-      capitalUSD: 1000,
-      fullRange: false
+      assumedPrice: null
    })
    const tokenSymbols = [pool.token0.symbol, pool.token1.symbol]
    
@@ -100,7 +101,6 @@ export default function PoolDetail() {
          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             {/* Range calculator */}
             <div className="bg-base-200 rounded-3xl p-6 shadow-lg">
-               <h2 className="text-xl font-semibold mb-4">Range Calculator</h2>
                <RangeCalculator 
                   pool={pool}
                   selectedTokenIdx={selectedTokenIdx}

--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -7,14 +7,23 @@ import { RangeCalculator } from "./RangeCalculator"
 export default function PoolDetail() {
    const { pool, history } = useLoaderData()
    const [selectedTokenIdx, setSelectedTokenIdx] = useState(0)
+   const [rangeInputs, setRangeInputs] = useState({
+      minPrice: null,
+      maxPrice: null,
+      capitalUSD: 1000,
+      fullRange: false
+   })
    const tokenSymbols = [pool.token0.symbol, pool.token1.symbol]
+   
+   const currentPrice = selectedTokenIdx === 0
+      ? (pool.token0Price || 0)
+      : (pool.token1Price || 0)
 
    useEffect(() => {
       window.scrollTo(0, 0)
    }, [])
 
    const latestSnapshot = history[history.length - 1] || {}
-
    const poolAgeDays = pool?.createdAtTimestamp
       ? Math.floor(Date.now() / 1000 - pool.createdAtTimestamp) / 86400
       : 0
@@ -95,6 +104,8 @@ export default function PoolDetail() {
                <RangeCalculator 
                   pool={pool}
                   selectedTokenIdx={selectedTokenIdx}
+                  inputs={rangeInputs}
+                  onInputsChange={setRangeInputs}
                />
             </div>
             <div className="bg-base-200 rounded-3xl p-6 shadow-lg">
@@ -111,6 +122,8 @@ export default function PoolDetail() {
                   history={history}
                   selectedTokenIdx={selectedTokenIdx}
                   tokenSymbols={tokenSymbols}
+                  rangeInputs={rangeInputs}
+                  currentPrice={currentPrice}
                />
             </div>
          </div>

--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -2,6 +2,7 @@ import { useLoaderData, Link } from "react-router-dom"
 import { useEffect, useState } from "react"
 import { TokenInfoBlock } from "./TokenInfoBlock"
 import { PoolCharts } from "./PoolCharts"
+import { RangeCalculator } from "./RangeCalculator"
 
 export default function PoolDetail() {
    const { pool, history } = useLoaderData()
@@ -86,22 +87,32 @@ export default function PoolDetail() {
                color="text-info"
             />
          </div>
-
-         {/* Token Info Block */}
-         <div className="grid gap-4 mb-6">
-            <TokenInfoBlock 
-               pool={pool}
-               selectedTokenIdx={selectedTokenIdx}
-               onTokenChange={setSelectedTokenIdx}
-            />
-         </div>
-         <div className="bg-base-200 rounded-3xl p-6 shadow-lg">
-            <h2 className="text-xl font-semibold mb-4">Historical Data</h2>
-            <PoolCharts 
-               history={history}
-               selectedTokenIdx={selectedTokenIdx}
-               tokenSymbols={tokenSymbols}
-            />
+         
+         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {/* Range calculator */}
+            <div className="bg-base-200 rounded-3xl p-6 shadow-lg">
+               <h2 className="text-xl font-semibold mb-4">Range Calculator</h2>
+               <RangeCalculator 
+                  pool={pool}
+                  selectedTokenIdx={selectedTokenIdx}
+               />
+            </div>
+            <div className="bg-base-200 rounded-3xl p-6 shadow-lg">
+               {/* Historical data */}
+               <h2 className="text-xl font-semibold mb-4">Historical Data</h2>
+               <div className="grid gap-4 mb-4">
+                  <TokenInfoBlock 
+                     pool={pool}
+                     selectedTokenIdx={selectedTokenIdx}
+                     onTokenChange={setSelectedTokenIdx}
+                  />
+               </div>
+               <PoolCharts 
+                  history={history}
+                  selectedTokenIdx={selectedTokenIdx}
+                  tokenSymbols={tokenSymbols}
+               />
+            </div>
          </div>
       </div>
    )

--- a/src/components/pool-detail/PriceChart.jsx
+++ b/src/components/pool-detail/PriceChart.jsx
@@ -66,7 +66,7 @@ export function PriceChart({
 
                {currentPrice > 0 && (
                   <ReferenceLine
-                     y={currentPrice}
+                     y={!rangeInputs.fullRange ? rangeInputs.assumedPrice : currentPrice}
                      stroke={CHART_COLORS.primary}
                      strokeDasharray="5 5"
                   />

--- a/src/components/pool-detail/PriceChart.jsx
+++ b/src/components/pool-detail/PriceChart.jsx
@@ -5,13 +5,20 @@ import {
    YAxis,
    CartesianGrid,
    Tooltip,
-   ResponsiveContainer
+   ResponsiveContainer,
+   ReferenceLine
 } from "recharts"
 import { CustomPriceTooltip } from "./CustomPriceTooltip"
 import { CHART_COLORS } from "../../utils/chartColors"
 import { formatCompactCurrency } from "../../utils/formatCompactCurrency"
 
-export function PriceChart({ history, selectedTokenIdx, tokenSymbols }) {
+export function PriceChart({ 
+   history, 
+   selectedTokenIdx, 
+   tokenSymbols,
+   rangeInputs,
+   currentPrice
+}) {
    const dataKey = selectedTokenIdx === 0 ? "token0Price" : "token1Price"
    const selectedSymbol = tokenSymbols[selectedTokenIdx]
    
@@ -37,6 +44,10 @@ export function PriceChart({ history, selectedTokenIdx, tokenSymbols }) {
                <YAxis 
                   stroke={CHART_COLORS.axis}
                   style={{ fontSize: "11px" }}
+                  domain={[
+                     (dataMin) => dataMin * 0.9,
+                     (dataMax) => dataMax * 1.1
+                  ]}
                   tickFormatter={(value) => (
                      value > 1
                         ? formatCompactCurrency(value)
@@ -52,6 +63,29 @@ export function PriceChart({ history, selectedTokenIdx, tokenSymbols }) {
                   dot={false}
                   name={`${selectedSymbol} Price`}
                />
+
+               {currentPrice > 0 && (
+                  <ReferenceLine
+                     y={currentPrice}
+                     stroke={CHART_COLORS.primary}
+                     strokeDasharray="5 5"
+                  />
+               )}
+
+               {!rangeInputs.fullRange && (
+                  <>
+                     <ReferenceLine 
+                        y={rangeInputs.minPrice}
+                        stroke={CHART_COLORS.secondary}
+                        strokeDasharray="5 5"
+                     />
+                     <ReferenceLine 
+                        y={rangeInputs.maxPrice}
+                        stroke={CHART_COLORS.secondary}
+                        strokeDasharray="5 5"
+                     />
+                  </>
+               )}
 
                <Tooltip content={
                   <CustomPriceTooltip 

--- a/src/components/pool-detail/PriceInputSection.jsx
+++ b/src/components/pool-detail/PriceInputSection.jsx
@@ -52,7 +52,7 @@ export function PriceInputSection({
                   aria-label="Future Price"
                />
             </div>
-            <label htmlFor="" className="label">
+            <label className="label">
                <span className="label-text-alt mt-2">{token0Symbol} Price</span>
                <span className="label-text-alt mt-2">
                   ({token0ChangePercent >= 0 ? "+" : ""}{token0ChangePercent}%)
@@ -89,7 +89,7 @@ export function PriceInputSection({
                   aria-label="Future Price"
                />
             </div>
-            <label htmlFor="" className="label">
+            <label className="label">
                <span className="label-text-alt mt-2">{token1Symbol} Price</span>
                <span className="label-text-alt mt-2">
                   ({token1ChangePercent >= 0 ? "+" : ""}{token1ChangePercent}%)

--- a/src/components/pool-detail/PriceInputSection.jsx
+++ b/src/components/pool-detail/PriceInputSection.jsx
@@ -1,0 +1,107 @@
+export function PriceInputSection({
+   token0Symbol,
+   token1Symbol,
+   currentToken0PriceUSD,
+   currentToken1PriceUSD,
+   futureToken0PriceUSD,
+   futureToken1PriceUSD,
+   onToken0PriceChange,
+   onToken1PriceChange
+}) {
+   const token0ChangePercent = currentToken0PriceUSD > 0
+      ? ((futureToken0PriceUSD - currentToken0PriceUSD) / currentToken0PriceUSD * 100).toFixed(2)
+      : "0.00"
+   const token1ChangePercent = currentToken1PriceUSD > 0
+      ? ((futureToken1PriceUSD - currentToken1PriceUSD) / currentToken1PriceUSD * 100).toFixed(2)
+      : "0.00"
+
+   return (
+      <div className="grid grid-cols-2 gap-4">
+         {/* Token0 Current Price (read-only) */}
+         <div className="form-control">
+            <label htmlFor="" className="label">
+               <span className="label-text mb-2 font-semibold">Current Price</span>
+            </label>
+            <div className="input input-bordered bg-base-300 flex items-center">
+               <span className="text-base-content/60">$</span>
+               <input 
+                  type="number" 
+                  value={currentToken0PriceUSD}
+                  disabled
+                  className="flex-1 bg-transparent"
+                  aria-label="Current Price"
+               />
+            </div>
+            <label htmlFor="" className="label">
+               <span className="label-text-alt mt-2">{token0Symbol} Price (USD)</span>
+            </label>
+         </div>
+
+         {/* Token0 Future Price (editable) */}
+         <div className="form-control">
+            <label htmlFor="" className="label">
+               <span className="label mb-2 font-semibold">Future Price</span>
+            </label>
+            <div className="input input-bordered flex items-center">
+               <span>$</span>
+               <input 
+                  type="number" 
+                  value={futureToken0PriceUSD}
+                  onChange={(e) => onToken0PriceChange(e.target.value)}
+                  step="0.000001"
+                  className="flex-1 bg-transparent"
+                  aria-label="Future Price"
+               />
+            </div>
+            <label htmlFor="" className="label">
+               <span className="label-text-alt mt-2">{token0Symbol} Price</span>
+               <span className={`label-text-alt font-bold mt-2 ${
+                  parseFloat(token0ChangePercent) >= 0 ? "text-success" : "text-error"
+               }`}>
+                  {token0ChangePercent >= 0 ? "+" : ""}{token0ChangePercent}%
+               </span>
+            </label>
+         </div>
+
+         {/* Token1 Current Price (read-only) */}
+         <div className="form-control">
+            <div className="input input-bordered bg-base-300 flex items-center">
+               <span className="text-base-content/60">$</span>
+               <input 
+                  type="text" 
+                  value={currentToken1PriceUSD}
+                  disabled
+                  className="flex-1 bg-transparent"
+                  aria-label="Current Price"
+               />
+            </div>
+            <label htmlFor="" className="label">
+               <span className="label-text-alt mt-2">{token1Symbol} Price (USD)</span>
+            </label>
+         </div>
+
+         {/* Token1 Future Price (editable) */}
+         <div className="form-control">
+            <div className="input input-bordered flex items-center">
+               <span>$</span>
+               <input 
+                  type="text" 
+                  value={futureToken1PriceUSD}
+                  onChange={(e) => onToken1PriceChange(e.target.value)}
+                  step="0.000001"
+                  className="flex-1 bg-transparent"
+                  aria-label="Future Price"
+               />
+            </div>
+            <label htmlFor="" className="label">
+               <span className="label-text-alt mt-2">{token1Symbol} Price</span>
+               <span className={`label-text-alt font-bold mt-2 ${
+                  parseFloat(token1ChangePercent) >= 0 ? "text-success" : "text-error"
+               }`}>
+                  {token1ChangePercent >= 0 ? "+" : ""}{token1ChangePercent}%
+               </span>
+            </label>
+         </div>
+      </div>
+   )
+}

--- a/src/components/pool-detail/PriceInputSection.jsx
+++ b/src/components/pool-detail/PriceInputSection.jsx
@@ -48,17 +48,14 @@ export function PriceInputSection({
                   type="number" 
                   value={futureToken0PriceUSD}
                   onChange={(e) => onToken0PriceChange(e.target.value)}
-                  step="0.000001"
                   className="flex-1 bg-transparent"
                   aria-label="Future Price"
                />
             </div>
             <label htmlFor="" className="label">
                <span className="label-text-alt mt-2">{token0Symbol} Price</span>
-               <span className={`label-text-alt font-bold mt-2 ${
-                  parseFloat(token0ChangePercent) >= 0 ? "text-success" : "text-error"
-               }`}>
-                  {token0ChangePercent >= 0 ? "+" : ""}{token0ChangePercent}%
+               <span className="label-text-alt mt-2">
+                  ({token0ChangePercent >= 0 ? "+" : ""}{token0ChangePercent}%)
                </span>
             </label>
          </div>
@@ -68,7 +65,7 @@ export function PriceInputSection({
             <div className="input input-bordered bg-base-300 flex items-center">
                <span className="text-base-content/60">$</span>
                <input 
-                  type="text" 
+                  type="number" 
                   value={currentToken1PriceUSD}
                   disabled
                   className="flex-1 bg-transparent"
@@ -85,20 +82,17 @@ export function PriceInputSection({
             <div className="input input-bordered flex items-center">
                <span>$</span>
                <input 
-                  type="text" 
+                  type="number" 
                   value={futureToken1PriceUSD}
                   onChange={(e) => onToken1PriceChange(e.target.value)}
-                  step="0.000001"
                   className="flex-1 bg-transparent"
                   aria-label="Future Price"
                />
             </div>
             <label htmlFor="" className="label">
                <span className="label-text-alt mt-2">{token1Symbol} Price</span>
-               <span className={`label-text-alt font-bold mt-2 ${
-                  parseFloat(token1ChangePercent) >= 0 ? "text-success" : "text-error"
-               }`}>
-                  {token1ChangePercent >= 0 ? "+" : ""}{token1ChangePercent}%
+               <span className="label-text-alt mt-2">
+                  ({token1ChangePercent >= 0 ? "+" : ""}{token1ChangePercent}%)
                </span>
             </label>
          </div>

--- a/src/components/pool-detail/RangeCalculator.jsx
+++ b/src/components/pool-detail/RangeCalculator.jsx
@@ -1,0 +1,250 @@
+import { useState, useEffect, useMemo, useCallback, useRef } from "react"
+import { CalculatorStats } from "./CalculatorStats"
+import { CalculatorInputs } from "./CalculatorInputs"
+import { useDebounce } from "../../hooks/useDebounce"
+import { simulateRangePerformance } from "../../utils/simulateRangePerformance"
+import { fetchPoolHourData } from "../../services/theGraphClient"
+
+export function RangeCalculator({ pool, selectedTokenIdx }) {
+   // === 1. STATE MANAGEMENT ===
+   const [inputs, setInputs] = useState({
+      capitalUSD: 1000,
+      minPrice: "",
+      maxPrice: "",
+      fullRange: false
+   })
+   const [hourlyData, setHourlyData] = useState(null)
+   const [isLoading, setIsLoading] = useState(true)
+   const [fetchError, setFetchError] = useState(null)
+
+   // === 1.5. AUTO-CONVERT INPUTS ON TOKEN FLIP ===
+   const prevTokenIdx = useRef(selectedTokenIdx)
+
+   useEffect(() => {
+      // Skip first render (no conversion needed)
+      if (prevTokenIdx.current === selectedTokenIdx) {
+         return
+      }
+      // Skip if fullRange (no inputs to convert)
+      if (inputs.fullRange) {
+         prevTokenIdx.current = selectedTokenIdx
+         return
+      }
+      // Skip if inputs are empty
+      if (inputs.minPrice === "" || inputs.maxPrice === "") {
+         prevTokenIdx.current = selectedTokenIdx
+         return
+      }
+      
+      // Convert existing inputs to new scale
+      const oldMin = Number(inputs.minPrice)
+      const oldMax = Number(inputs.maxPrice)
+
+      // Validate before conversion
+      if (oldMin <= 0 || oldMax <= 0 || !isFinite(oldMin) || !isFinite(oldMax)) {
+         prevTokenIdx.current = selectedTokenIdx
+         return
+      }
+
+      // Invert AND swap (min becomes max and vice versa)
+      const newMin = 1 / oldMax
+      const newMax = 1 / oldMin
+
+      setInputs(prev => ({
+         ...prev,
+         minPrice: newMin.toFixed(8), // Preserve precision
+         maxPrice: newMax.toFixed(8)
+      }))
+
+      prevTokenIdx.current = selectedTokenIdx
+   }, [selectedTokenIdx, inputs.fullRange, inputs.minPrice, inputs.maxPrice])
+
+   // === 2. DEBOUNCING ===
+   const debouncedInputs = useDebounce(inputs, 500)
+
+   // === 3. DATA FETCHING ===
+   useEffect(() => {
+      let cancelled = false
+
+      async function loadHourlyData() {
+         try {
+            const startTime = Math.floor(Date.now() / 1000) - (7 * 24 * 60 * 60)
+            const data = await fetchPoolHourData(pool.id, startTime)
+
+            console.log('🔍 Query params:', {
+               poolId: pool.id,
+               startTime,
+               startDate: new Date(startTime * 1000).toISOString(),
+               expectedSnapshots: 7 * 24 // 168
+            })
+
+            if (data?.length > 0) {
+               const actualHours = (data[data.length - 1].periodStartUnix - data[0].periodStartUnix) / 3600
+               console.log('📊 Coverage:', {
+                  snapshots: data.length,
+                  actualHours: Math.round(actualHours),
+                  completeness: (data.length / 168 * 100).toFixed(1) + '%'
+               })
+            }
+
+            // 🔍 DIAGNOSTIC
+            console.group('🔍 Hourly Data Diagnostic')
+            console.log('Pool ID:', pool.id)
+            console.log('Requested startTime:', new Date(startTime * 1000))
+            console.log('Data received:', data?.length || 0, 'snapshots')
+            if (data?.length > 0) {
+            console.log('First snapshot:', {
+               time: new Date(data[0].periodStartUnix * 1000),
+               token0Price: data[0].token0Price,
+               liquidity: data[0].liquidity,
+               feesUSD: data[0].feesUSD
+            })
+            console.log('Last snapshot:', {
+               time: new Date(data[data.length - 1].periodStartUnix * 1000),
+               token0Price: data[data.length - 1].token0Price
+            })
+            }
+            console.groupEnd()
+
+            if (!cancelled) {
+               setHourlyData(data)
+               setIsLoading(false)
+            }
+         } catch (err) {
+            console.error('❌ Fetch error:', err)
+            if (!cancelled) {
+               setFetchError(err.message)
+               setIsLoading(false)
+            }
+         }
+      }
+
+      loadHourlyData()
+      return () => { cancelled = true }
+   }, [pool.id])
+
+   // === 4. EVENT HANDLERS ===
+   const handleInputChange = useCallback((field, value) => {
+      setInputs(prev => ({ ...prev, [field]: value }))
+   }, [])
+
+   // === 5. PRICE CALCULATIONS (DEFENSIVE) ===
+   // 5.1 Get current price (prefer hourly data)
+   const { token0PriceUSD, token1PriceUSD } = useMemo(() => {
+      const currentPrice = hourlyData?.[0]?.token0Price
+         ? parseFloat(hourlyData[0].token0Price)
+         : parseFloat(pool.token0Price)
+      
+      const tvlUSD = parseFloat(pool.totalValueLockedUSD)
+      const tvl0 = parseFloat(pool.totalValueLockedToken0)
+      const tvl1 = parseFloat(pool.totalValueLockedToken1)
+
+      // 5.2 Basic validation
+      if (tvlUSD <= 0 || tvl0 <= 0 || tvl1 <= 0 || currentPrice <= 0) {
+         return { token0PriceUSD: 0, token1PriceUSD: 0 }
+      }
+
+      // 5.3 Try inference formula first
+      let price1USD = tvlUSD / (tvl0 / currentPrice + tvl1)
+      let price0USD = price1USD / currentPrice
+
+      // 5.4 Validate inference result (sanity check)
+      const inferenceIsValid =
+         isFinite(price0USD) &&
+         isFinite(price1USD) &&
+         price0USD > 0 &&
+         price1USD > 0 &&
+         // Sanity: neither token should be > $1M (unless it's a whale token)
+         price0USD < 1_000_000 &&
+         price1USD < 1_000_000 &&
+         // Sanity: TVL reconstruction should match (within 10% error)
+         Math.abs((tvl0 * price0USD + tvl1 * price1USD) - tvlUSD) / tvlUSD < 0.1
+
+      // 5.5 If inference failed, use stablecoin heuristic as fallback
+      if (!inferenceIsValid) {
+         const stableSymbols = ["USDT", "USDC", "DAI", "BUSD", "FRAX", "TUSD", "USDD"]
+         const token0IsStable = stableSymbols.includes(pool.token0.symbol)
+         const token1IsStable = stableSymbols.includes(pool.token1.symbol)
+
+         if (token1IsStable) {
+            // token1 is stablecoin → token1 = $1, derive token0
+            price1USD = 1
+            price0USD = currentPrice // currentPrice is "token1 per token0" = "USD per token0"
+         } else if (token0IsStable) {
+            // token0 is stablecoin → token0 = $1, derive token1
+            price0USD = 1
+            price1USD = 1 / currentPrice // invert to get USD per token1
+         } else {
+            // No stablecoin, inference failed → return 0 (will show "N/A")
+            console.warn("Price inference failed and no stablecoin detected", {
+               pool: pool.id,
+               price0USD,
+               price1USD,
+               tvlUSD,
+               currentPrice
+            })
+            return { token0PriceUSD: 0, token1PriceUSD: 0 }
+         }
+      }
+
+      return { token0PriceUSD: price0USD, token1PriceUSD: price1USD }
+   }, [hourlyData, pool.id, pool.token0Price, pool.token0.symbol, pool.token1.symbol, pool.totalValueLockedUSD, pool.totalValueLockedToken0, pool.totalValueLockedToken1])
+
+   // === 6. DISPLAY ===
+   const displayPrice = useMemo(() => {
+      const price = selectedTokenIdx === 0
+         ? Number(pool.token0Price)
+         : Number(pool.token1Price)
+
+      return price
+   }, [selectedTokenIdx, pool.token0Price, pool.token1Price])
+
+   const priceLabel = useMemo(() => {
+      return selectedTokenIdx === 0
+         ? `${pool.token0.symbol} per ${pool.token1.symbol}`
+         : `${pool.token1.symbol} per ${pool.token0.symbol}`
+   }, [selectedTokenIdx, pool.token0.symbol, pool.token1.symbol])
+
+   // === 7. RESULTS (MEMOIZED) ===
+   const results = useMemo(() => {
+      if (!hourlyData) return null
+
+      return simulateRangePerformance({
+         capitalUSD: debouncedInputs.capitalUSD,
+         minPrice: debouncedInputs.minPrice === "" ? null : Number(debouncedInputs.minPrice),
+         maxPrice: debouncedInputs.maxPrice === "" ? null : Number(debouncedInputs.maxPrice),
+         fullRange: debouncedInputs.fullRange,
+         selectedTokenIdx,
+         hourlyData,
+         pool
+      })
+   }, [debouncedInputs, selectedTokenIdx, hourlyData, pool])
+
+   return (
+      <div className="grid gap-6">
+         {/* Left Column: Stats + Inputs */}
+         <div className="flex flex-col gap-6">
+            <div className="card rounded-2xl bg-base-200">
+               <CalculatorStats 
+                  results={results}
+                  isLoading={isLoading}
+                  fetchError={fetchError}
+               />
+            </div>
+
+            <div className="card rounded-2xl bg-base-200">
+               <CalculatorInputs 
+                  inputs={inputs}
+                  onChange={handleInputChange}
+                  currentPrice={displayPrice}
+                  priceLabel={priceLabel}
+                  token0Symbol={pool.token0.symbol}
+                  token1Symbol={pool.token1.symbol}
+                  token0PriceUSD={token0PriceUSD}
+                  token1PriceUSD={token1PriceUSD}
+               />
+            </div>
+         </div>
+      </div>
+   )
+}

--- a/src/components/pool-detail/StrategyComparison.jsx
+++ b/src/components/pool-detail/StrategyComparison.jsx
@@ -1,0 +1,94 @@
+export function StrategyComparison({
+   hodlStrategy,
+   lpStrategy,
+   isCalculating
+}) {
+   const winner = lpStrategy?.pnl > hodlStrategy?.pnl ? "lp" : "hodl"
+
+   // 🔍 DIAGNOSTIC
+   console.log("HODL Strategy:", hodlStrategy)
+   console.log("LP Strategy:", lpStrategy)
+
+   return (
+      <div className="grid gap-4">
+         {/* HODL Card */}
+         <StrategyCard 
+            title="Strategy A: HODL"
+            isWinner={winner === "hodl"}
+            data={hodlStrategy}
+            isCalculating={isCalculating}
+         />
+         {/* LP Card */}
+         <StrategyCard 
+            title="Strategy B: Uniswap V3"
+            isWinner={winner === "lp"}
+            data={lpStrategy}
+            isCalculating={isCalculating}
+         />
+      </div>
+   )
+}
+
+function StrategyCard({ title, isWinner, data, isCalculating }) {
+   return (
+      <div
+         className={`
+            card bg-base-300 rounded-2xl p-4 mb-4
+            ${isWinner ? "ring-2 ring-success" : ""}
+      `}>
+         <div className="flex justify-between items-center mb-4">
+            <h4 className="font">{title}</h4>
+            {isWinner && (
+               <span className="badge badge-success">Best</span>
+            )}
+         </div>
+         
+         {isCalculating || !data ? (
+            <div className="skeleton h-32" />
+         ) : (
+            <div className="space-y-2">
+               {/* Token composition */}
+               <div className="text-sm">
+                  <div className="flex justify-between">
+                     <span className="text-base-content/60">{data.token0Symbol}</span>
+                     <span>{data.amount0.toFixed(4)} ({data.token0Percent}%)</span>
+                  </div>
+                  <div className="flex justify-between">
+                     <span className="text-base-content/60">{data.token1Symbol}</span>
+                     <span>{data.amount1.toFixed(4)} ({data.token1Percent}%)</span>
+                  </div>
+               </div>
+
+               <div className="divider my-2" />
+
+               {/* P&L metrics */}
+               <div className="flex justify-between font-bold">
+                  <span>Value</span>
+                  <span>${data.totalValue.toFixed(2)}</span>
+               </div>
+
+               <div className="flex justify-between">
+                  <span>P&L</span>
+                  <span className={data.pnl >= 0 ? "text-success" : "text-error"}>
+                     {data.pnl >= 0 ? "+" : ""}${data.pnl.toFixed(2)} ({data.pnlPercent}%)
+                  </span>
+               </div>
+
+               {/* LP-specific metrics */}
+               {data.feesEarned !== undefined && (
+                  <>
+                     <div className="flex justify-between text-sm">
+                        <span className="text-base-content/60">Fees Earned</span>
+                        <span className="text-success">+${data.feesEarned.toFixed(2)}</span>
+                     </div>
+                     <div className="flex justify-between text-sm">
+                        <span className="text-base-content/60">Impermanent Loss</span>
+                        <span className="text-error">{data.ilPercent}%</span>
+                     </div>
+                  </>
+               )}
+            </div>
+         )}
+      </div>
+   )
+}

--- a/src/components/pool-detail/TimeLineControl.jsx
+++ b/src/components/pool-detail/TimeLineControl.jsx
@@ -1,0 +1,58 @@
+export function TimeLineControl({ days, onDaysChange, daysToBreakEven }) {
+   const increment = () => onDaysChange(Math.min(days + 1, 365))
+   const decrement = () => onDaysChange(Math.max(days - 1, 0))
+
+   console.log("Days to BE:", daysToBreakEven)
+
+   return (
+      <div className="form-control">
+         <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col items-center gap-2">
+               <label className="label">
+                  <span className="label-text font-semibold">Days of Active Position</span>
+               </label>
+               <label className="label">
+                  <span className="label-text-alt text-warning text-center text-wrap">
+                     {`Position must be active ≥ ${daysToBreakEven.toFixed(2)}d to cover IL`}
+                  </span>
+               </label>
+            </div>
+
+            <div className="flex items-center gap-2">
+               <button 
+                  type="button"
+                  onClick={decrement}
+                  className="btn btn-circle btn-sm"
+               >
+                  −
+               </button>
+               
+               <input 
+                  type="text"
+                  value={days}
+                  onChange={(e) => {
+                     const val = parseInt(e.target.value)
+                     if (!isNaN(val)) {
+                        onDaysChange(0)
+                     } else {
+                        onDaysChange(Math.max(0, Math.min(val, 365)))
+                     }
+                  }}
+                  min="0"
+                  max="365"
+                  className="input input-bordered text-center" 
+                  aria-label="Days of active position."
+               />
+
+               <button 
+                  type="button"
+                  onClick={increment}
+                  className="btn btn-circle btn-sm"
+               >
+                  +
+               </button>
+            </div>
+         </div>
+      </div>
+   )
+}

--- a/src/components/pool-detail/TimeLineControl.jsx
+++ b/src/components/pool-detail/TimeLineControl.jsx
@@ -2,8 +2,6 @@ export function TimeLineControl({ days, onDaysChange, daysToBreakEven }) {
    const increment = () => onDaysChange(Math.min(days + 1, 365))
    const decrement = () => onDaysChange(Math.max(days - 1, 0))
 
-   console.log("Days to BE:", daysToBreakEven)
-
    return (
       <div className="form-control">
          <div className="grid grid-cols-2 gap-4">

--- a/src/components/pool-detail/TimeLineControl.jsx
+++ b/src/components/pool-detail/TimeLineControl.jsx
@@ -28,11 +28,11 @@ export function TimeLineControl({ days, onDaysChange, daysToBreakEven }) {
                </button>
                
                <input 
-                  type="text"
+                  type="number"
                   value={days}
                   onChange={(e) => {
                      const val = parseInt(e.target.value)
-                     if (!isNaN(val)) {
+                     if (isNaN(val)) {
                         onDaysChange(0)
                      } else {
                         onDaysChange(Math.max(0, Math.min(val, 365)))

--- a/src/components/pool-detail/TokenInfoBlock.jsx
+++ b/src/components/pool-detail/TokenInfoBlock.jsx
@@ -58,7 +58,7 @@ export function TokenInfoBlock({ pool, selectedTokenIdx, onTokenChange }) {
    }
 
    return (
-      <div className="rounded-2xl bg-base-200 p-4 mb-4">
+      <div className="rounded-2xl bg-base-200 mb-4">
          {/* Current Price */}
          {currentPrice && (
             <div className="mb-3 p-3 rounded-lg bg-base-300">

--- a/src/docs/FEE_CALCULATION.md
+++ b/src/docs/FEE_CALCULATION.md
@@ -1,0 +1,144 @@
+# Uniswap V3 Liquidity-Based Fee Calculation
+
+**Branch:** `feat/range-calculator`  
+**Purpose:** Simulate concentrated liquidity positions with accurate fee accumulation
+
+## Overview
+
+This implementation calculates fee share based on **liquidity contribution** rather than TVL ratio, accurately reflecting the concentration advantage of Uniswap V3 positions.
+
+## Core Concept
+
+In Uniswap V3, concentrated positions earn more fees because they provide **higher liquidity density** at specific price points. A $1,000 position in a ±5% range contributes more "active liquidity" than the same capital spread across full range.
+
+## Mathematical Foundation
+
+### Liquidity Formula (Off-Chain)
+
+We use Uniswap V3's liquidity formulas adapted for off-chain simulation:
+
+```javascript
+// From token0 contribution
+L0 = amount0 * (√price * √maxPrice) / (√maxPrice - √price)
+
+// From token1 contribution  
+L1 = amount1 / (√price - √minPrice)
+
+// Conservative approach (bottleneck principle)
+L_user = Math.min(L0, L1)
+```
+
+**Why Math.min()?** Both tokens must be present for swaps to execute in both directions. The limiting factor determines effective liquidity.
+
+### Fee Share Calculation
+
+```javascript
+feeShare = L_user / (L_user + L_pool)
+```
+
+Where:
+- `L_user`: User's liquidity (calculated above)
+- `L_pool`: Pool's total liquidity from TheGraph (hourly snapshots)
+
+### Impermanent Loss Calculation
+
+```javascript
+// Classic AMM formula
+priceRatio = finalPrice / initialPrice
+IL_decimal = (2 × √priceRatio) / (1 + priceRatio) - 1
+```
+
+**Used in:**
+- Historical backtest: Compare initial vs final pool price
+- Future projections: Compare current vs user-input future price  
+- Strategy comparison: HODL value vs LP value (capital × (1 + IL))
+
+**Implementation:** `src/utils/calculateIL.js`
+
+### Universal Normalization
+
+On-chain liquidity values are scaled by token decimals. To compare `L_user` (off-chain) with `L_pool` (on-chain), we normalize using the **geometric mean of token decimals**:
+
+```javascript
+exponent = (decimals0 + decimals1) / 2
+L_pool_normalized = L_pool_onchain / 10^exponent
+```
+
+**Examples:**
+- WETH (18) / USDC (6): exponent = 12 → factor = 10^12
+- DAI (18) / USDC (6): exponent = 12 → factor = 10^12  
+- WETH (18) / DAI (18): exponent = 18 → factor = 10^18
+
+### Precision Handling
+
+We use `BigInt` for on-chain liquidity values to avoid IEEE 754 precision loss:
+
+```javascript
+const L_pool_bigint = BigInt(hour.liquidity) // Preserves all digits
+const L_pool_normalized = Number(L_pool_bigint) / Math.pow(10, exponent)
+```
+
+**Why?** On-chain liquidity values (~10^18) exceed JavaScript's `Number.MAX_SAFE_INTEGER` (2^53 - 1). `parseFloat()` would lose precision in the last digits.
+
+## Implementation Details
+
+### File Structure
+
+```
+src/utils/
+├── calculateLiquidity.js          # L_user calculation
+├── calculateIL.js                 # Impermanent loss formula
+└── simulateRangePerformance.js    # Fee accumulation loop
+```
+
+### Integration Points
+
+**Liquidity calculation (Stage 4.6):**
+```javascript
+const L_user = calculateLiquidity(
+   amount0, amount1,
+   currentPrice, effectiveMin, effectiveMax
+)
+```
+
+**Fee accumulation (Stage 5.5):**
+```javascript
+const L_pool_bigint = BigInt(hour.liquidity)
+const L_pool_normalized = Number(L_pool_bigint) / Math.pow(10, liquidityExponent)
+const feeShare = L_user / (L_pool_normalized + L_user)
+totalFeesUSD += hourFeesUSD * feeShare
+```
+
+### Key Edge Cases
+
+1. **Price outside range:** `L_user = 0` (position inactive)
+2. **Price at boundaries:** `L_user = 0` (avoid division by zero)
+3. **Invalid pool data:** Skip hour if `L_pool <= 0`
+
+### Validation Strategy
+
+Compare fee share with TVL-based baseline:
+
+```javascript
+expectedFeeShare = capitalUSD / poolTVL  // Baseline (full range)
+actualFeeShare = L_user / (L_user + L_pool) // Should be 3-30x higher for concentrated ranges
+```
+
+## Performance Impact
+
+- **Full range (±∞):** Fee share ≈ TVL ratio (1x)
+- **±50% range:** 2-5x higher  
+- **±10% range:** 5-15x higher
+- **±5% range:** 10-30x higher
+
+## Technical Debt & Limitations
+
+- **Current tick check:** We use `price >= minPrice && price <= maxPrice` instead of tick-based range checking (acceptable for off-chain simulation)
+- **Assumes static composition:** Token amounts don't change during simulation (IL affects value, not quantities)
+- **Hourly granularity:** Fee accumulation based on hourly snapshots, not per-block precision
+
+## References
+
+- [Uniswap V3 Whitepaper](https://uniswap.org/whitepaper-v3.pdf) - Section 6.2 (Liquidity)
+- [Uniswap V3 Development Book](https://uniswapv3book.com/docs/milestone_3/calculating-liquidity/) - Practical implementation  
+- [MDN BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) - Precision handling

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react"
 
-export default function useDebounce(value, delay) {
+export function useDebounce(value, delay) {
    const [debouncedValue, setDebouncedValue] = useState(value)
    const valueRef = useRef(value)
 

--- a/src/hooks/useProjectionCalculator.js
+++ b/src/hooks/useProjectionCalculator.js
@@ -1,0 +1,135 @@
+import { useState, useMemo, useEffect } from "react"
+import { calculateTokenPrices } from "../utils/calculateTokenPrices"
+import { calculateIL } from "../utils/calculateIL"
+
+export function useProjectionCalculator(poolData, rangeInputs, results) {
+   // Calculate current prices using utility
+   const { token0PriceUSD, token1PriceUSD } = useMemo(() => {
+      const currentPrice = parseFloat(poolData.token0Price)
+      return calculateTokenPrices(poolData, currentPrice)
+   }, [poolData])
+
+   // User inputs state
+   const [futureToken0Price, setFutureToken0Price] = useState(token0PriceUSD)
+   const [futureToken1Price, setFutureToken1Price] = useState(token1PriceUSD)
+   const [projectionDays, setProjectionDays] = useState(0)
+
+   // Update state with current price change
+   useEffect(() => {
+      setFutureToken0Price(token0PriceUSD)
+      setFutureToken1Price(token1PriceUSD)
+   }, [token0PriceUSD, token1PriceUSD])
+
+   /**
+    * SIMPLIFICATIONS:
+    * 1. Token amounts stay constant (amount0, amount1 from initial composition)
+    *    Reality: AMM rebalances as price moves
+    * 2. Fees projected linearly (dailyFeesUSD × days)
+    *    Reality: Fee rate varies with volume/volatility
+    * 3. Assumes position stays in-range entire period
+    *    Reality: If price exits range, fees = 0
+    * 
+    * Accuracy: Good for ±20% price moves over 7-30 days
+    */
+
+   // Calculate strategies
+   const { hodlStrategy, lpStrategy, daysToBreakEven } = useMemo(() => {
+      if (!results?.success) {
+         return { hodlStrategy: null, lpStrategy: null, daysToBreakEven: 0 }
+      }
+      if (futureToken0Price <= 0 || futureToken1Price <= 0) {
+         return { hodlStrategy: null, lpStrategy: null, daysToBreakEven: 0 }
+      }
+      if (projectionDays < 0) {
+         return { hodlStrategy: null, lpStrategy: null, daysToBreakEven: 0 }
+      }
+
+      const capitalUSD = rangeInputs.capitalUSD || 1000
+      const { amount0, amount1, token0Percent, token1Percent } = results.composition
+
+      // Calculate IL value
+      const currentPriceRatio = token0PriceUSD / token1PriceUSD
+      const futurePriceRatio = futureToken0Price / futureToken1Price
+      const IL_decimal = calculateIL(currentPriceRatio, futurePriceRatio)
+      const lpValueBeforeFees = capitalUSD * (1 + IL_decimal)
+
+      // Calculate days to cover IL
+      const ilLoss = Math.abs(lpValueBeforeFees - capitalUSD)
+      const daysToBreakEven = results.dailyFeesUSD > 0
+         ? ilLoss / results.dailyFeesUSD
+         : 0
+
+      // ===== HODL STRATEGY =====
+      const hodlFutureValue =
+         amount0 * futureToken0Price +
+         amount1 * futureToken1Price
+
+      const hodl = {
+         token0Symbol: poolData.token0.symbol,
+         token1Symbol: poolData.token1.symbol,
+         amount0,
+         amount1,
+         token0Percent,
+         token1Percent,
+         totalValue: hodlFutureValue,
+         pnl: hodlFutureValue - capitalUSD,
+         pnlPercent: ((hodlFutureValue - capitalUSD) / capitalUSD * 100).toFixed(2)
+      }
+
+      // ===== LP STRATEGY =====
+      const IL_percent = (IL_decimal * 100).toFixed(2)
+      const projectedFees = projectionDays > 0
+         ? results.dailyFeesUSD * projectionDays
+         : 0
+      const lpFutureValue = lpValueBeforeFees + projectedFees
+
+      const lp = {
+         token0Symbol: poolData.token0.symbol,
+         token1Symbol: poolData.token1.symbol,
+         amount0,
+         amount1,
+         token0Percent,
+         token1Percent,
+         totalValue: lpFutureValue,
+         pnl: lpFutureValue - capitalUSD,
+         pnlPercent: ((lpFutureValue - capitalUSD) / capitalUSD * 100).toFixed(2),
+         feesEarned: projectedFees,
+         ilPercent: IL_percent
+      }
+
+      return { hodlStrategy: hodl, lpStrategy: lp, daysToBreakEven }
+   }, [
+      results,
+      futureToken0Price,
+      futureToken1Price,
+      projectionDays,
+      rangeInputs.capitalUSD,
+      token0PriceUSD,
+      token1PriceUSD,
+      poolData
+   ])
+
+   const isCalculating = !hodlStrategy || !lpStrategy
+
+   return {
+      // Calculated data
+      hodlStrategy,
+      lpStrategy,
+      isCalculating,
+      daysToBreakEven,
+
+      // Current prices
+      currentToken0PriceUSD: token0PriceUSD,
+      currentToken1PriceUSD: token1PriceUSD,
+
+      // Inputs state
+      futureToken0Price,
+      futureToken1Price,
+      projectionDays,
+
+      // Handlers
+      setFutureToken0Price,
+      setFutureToken1Price,
+      setProjectionDays
+   }
+}

--- a/src/services/theGraphClient.js
+++ b/src/services/theGraphClient.js
@@ -73,11 +73,13 @@ const GET_POOL_HISTORY_QUERY = gql`
             id
             symbol
             name
+            decimals
          }
          token1 {
             id
             symbol
             name
+            decimals
          }
          createdAtTimestamp
       }

--- a/src/services/theGraphClient.js
+++ b/src/services/theGraphClient.js
@@ -66,6 +66,7 @@ const GET_POOL_HISTORY_QUERY = gql`
          feeTier
          totalValueLockedToken0
          totalValueLockedToken1
+         totalValueLockedUSD
          token0Price
          token1Price
          token0 {

--- a/src/services/theGraphClient.js
+++ b/src/services/theGraphClient.js
@@ -43,6 +43,7 @@ const GET_POOLS_QUERY = gql`
          collectedFeesToken0
          collectedFeesToken1
          token0Price
+         token1Price
          createdAtTimestamp
          token0 {
             id
@@ -74,14 +75,21 @@ const GET_POOL_HISTORY_QUERY = gql`
             symbol
             name
             decimals
+            derivedETH
          }
          token1 {
             id
             symbol
             name
             decimals
+            derivedETH
          }
          createdAtTimestamp
+      }
+      
+      # Internal oracle to convert from ETH to USD
+      bundle(id: "1") {
+         ethPriceUSD
       }
 
       # Historical snapshots (daily)

--- a/src/services/theGraphClient.js
+++ b/src/services/theGraphClient.js
@@ -101,6 +101,29 @@ const GET_POOL_HISTORY_QUERY = gql`
    }
 `
 
+const GET_POOL_HOUR_DATAS_QUERY = gql`
+   query GetPoolHourDatas($poolId: String!, $startTime: Int!) {
+      poolHourDatas(
+         where: {
+            pool: $poolId
+            periodStartUnix_gte: $startTime
+         }
+         orderBy: periodStartUnix
+         orderDirection: asc
+         first: 720
+      ) {
+         periodStartUnix
+         token0Price
+         token1Price
+         feesUSD
+         sqrtPrice
+         liquidity
+         tvlUSD
+         tick   
+      }
+   }
+`
+
 // 3. Exported functions
 /**
  * Fetches pools from Uniswap v3 subgraph
@@ -135,4 +158,19 @@ export async function fetchPoolHistory(poolId, startDate) {
       pool: data.pool,
       history: data.poolDayDatas
    }
+}
+
+/**
+ * Fetches hourly historical data for a specific pool
+ * @param {string} poolId - Pool contract address (lowercase)
+ * @param {number} startTime - Unix timestamp (seconds) for oldest data point
+ * @returns {Promise<Array>} Array of hourly snapshots (up to 720 items)
+ */
+
+export async function fetchPoolHourData(poolId, startTime) {
+   const data = await client.request(GET_POOL_HOUR_DATAS_QUERY, {
+      poolId: poolId.toLowerCase(),
+      startTime
+   })
+   return data.poolHourDatas
 }

--- a/src/utils/assessDataQuality.js
+++ b/src/utils/assessDataQuality.js
@@ -1,0 +1,8 @@
+export function assessDataQuality(hourlyData) {
+   const hours = hourlyData.length
+
+   if (hours < 168) return { quality: "INSUFFICIENT", warnings: [] }
+   if (hours < 336) return { quality: "LIMITED", warnings: "Less than 14 days of data."}
+   if (hours < 720) return { quality: "RELIABLE", warnings: [] }
+   return { quality: "EXCELLENT", warnings: [] }
+}

--- a/src/utils/calculateIL.js
+++ b/src/utils/calculateIL.js
@@ -1,0 +1,18 @@
+/**
+ * Calculate Impermanent Loss using AMM formula
+ * @param {number} initialPrice - Starting price ratio
+ * @param {number} finalPrice - Ending price ratio
+ * @returns {number} IL as decimal (e.g. -0.057 = -5.7% loss)
+ */
+export function calculateIL(initialPrice, finalPrice) {
+   if (initialPrice <= 0 || finalPrice <= 0) {
+      throw new Error("Prices must be positive")
+   }
+
+   const priceRatio = finalPrice / initialPrice
+
+   // Classic IL formula: 2 x √(ratio) / (1 + ratio) - 1
+   const IL_decimal = (2 * Math.sqrt(priceRatio)) / (1 + priceRatio) - 1
+
+   return IL_decimal
+}

--- a/src/utils/calculateLiquidity.js
+++ b/src/utils/calculateLiquidity.js
@@ -1,0 +1,37 @@
+/**
+ * amount0
+ * amount1
+ * price
+ * minPrice
+ * maxPrice
+ * 
+ */
+
+/**
+ * Calculates Uniswap V3 liquidity (L) for a position
+ * @param {number} amount0 - Token0 amount in position
+ * @param {number} amount1 - Token1 amount in position
+ * @param {number} price - Current price (token1/token0)
+ * @param {number} minPrice - Lower bound of the range
+ * @param {number} maxPrice - Upper bound of the range
+ * @returns {number} L_user - Liquidity value
+ */
+export function calculateLiquidity(amount0, amount1, price, minPrice, maxPrice) {
+   // Edge case 1 - Price outside range
+   if (price <= minPrice || price >= maxPrice) {
+      return 0
+   }
+   // Step 1: Calculate sqrt values
+   const sqrtPrice = Math.sqrt(price)
+   const sqrtMinPrice = Math.sqrt(minPrice)
+   const sqrtMaxPrice = Math.sqrt(maxPrice)
+
+   // Step 2: Calculate L0 (from token0)
+   const L0 = amount0 * (sqrtPrice * sqrtMaxPrice) / (sqrtMaxPrice - sqrtPrice)
+
+   // Step 3: Calculate L1 (from token1)
+   const L1 = amount1 * (sqrtPrice * sqrtMinPrice)
+   
+   // Step 4: Return conservative value
+   return Math.min(L0, L1)
+}

--- a/src/utils/calculateLiquidity.js
+++ b/src/utils/calculateLiquidity.js
@@ -1,10 +1,6 @@
 /**
- * amount0
- * amount1
- * price
- * minPrice
- * maxPrice
- * 
+ * Uniswap V3 whitepaper
+ * Reference: https://uniswap.org/whitepaper-v3.pdf
  */
 
 /**

--- a/src/utils/calculatePresetRange.js
+++ b/src/utils/calculatePresetRange.js
@@ -1,11 +1,10 @@
 /**
  * Calculates min/max price range based on preset type
- * @param {number} currentPrice - Base price to calculate from
- * @param {number} selectedTokenIdx - 0 for token0, 1 for token1
+ * @param {number} assumedPrice - Base price to calculate from
  * @param {string} presetType - "±10%" | "±20%" | "fullRange"
  * @returns {{ minPrice: number, maxPrice: number }}
  */
-export function calculatePresetRange(currentPrice, selectedTokenIdx, presetType) {
+export function calculatePresetRange(assumedPrice, presetType) {
    const multipliers = {
       "±10%": { min: 0.9, max: 1.1 },
       "±15%": { min: 0.85, max: 1.15 },
@@ -14,8 +13,8 @@ export function calculatePresetRange(currentPrice, selectedTokenIdx, presetType)
 
    const { min, max } = multipliers[presetType]
 
-   const minPrice = (currentPrice * min).toFixed(8)
-   const maxPrice = (currentPrice * max).toFixed(8)
+   const minPrice = (assumedPrice * min).toFixed(8)
+   const maxPrice = (assumedPrice * max).toFixed(8)
 
    return { minPrice, maxPrice }
 }

--- a/src/utils/calculatePresetRange.js
+++ b/src/utils/calculatePresetRange.js
@@ -1,0 +1,21 @@
+/**
+ * Calculates min/max price range based on preset type
+ * @param {number} currentPrice - Base price to calculate from
+ * @param {number} selectedTokenIdx - 0 for token0, 1 for token1
+ * @param {string} presetType - "±10%" | "±20%" | "fullRange"
+ * @returns {{ minPrice: number, maxPrice: number }}
+ */
+export function calculatePresetRange(currentPrice, selectedTokenIdx, presetType) {
+   const multipliers = {
+      "±10%": { min: 0.9, max: 1.1 },
+      "±15%": { min: 0.85, max: 1.15 },
+      "±20%": { min: 0.8, max: 1.2 },
+   }
+
+   const { min, max } = multipliers[presetType]
+
+   const minPrice = (currentPrice * min).toFixed(8)
+   const maxPrice = (currentPrice * max).toFixed(8)
+
+   return { minPrice, maxPrice }
+}

--- a/src/utils/calculateTokenPrices.js
+++ b/src/utils/calculateTokenPrices.js
@@ -1,0 +1,55 @@
+export function calculateTokenPrices(pool, currentPrice) {
+   const tvlUSD = parseFloat(pool.totalValueLockedUSD)
+   const tvl0 = parseFloat(pool.totalValueLockedToken0)
+   const tvl1 = parseFloat(pool.totalValueLockedToken1)
+
+   // 6.2 Basic validation
+   if (tvlUSD <= 0 || tvl0 <= 0 || tvl1 <= 0 || currentPrice <= 0) {
+      return { token0PriceUSD: 0, token1PriceUSD: 0 }
+   }
+
+   // 6.3 Try inference formula first
+   let price1USD = tvlUSD / (tvl0 / currentPrice + tvl1)
+   let price0USD = price1USD / currentPrice
+
+   // 6.4 Validate inference result (sanity check)
+   const inferenceIsValid =
+      isFinite(price0USD) &&
+      isFinite(price1USD) &&
+      price0USD > 0 &&
+      price1USD > 0 &&
+      // Sanity: neither token should be > $1M (unless it's a whale token)
+      price0USD < 1_000_000 &&
+      price1USD < 1_000_000 &&
+      // Sanity: TVL reconstruction should match (within 10% error)
+      Math.abs((tvl0 * price0USD + tvl1 * price1USD) - tvlUSD) / tvlUSD < 0.1
+
+   // 6.5 If inference failed, use stablecoin heuristic as fallback
+   if (!inferenceIsValid) {
+      const stableSymbols = ["USDT", "USDC", "DAI", "BUSD", "FRAX", "TUSD", "USDD"]
+      const token0IsStable = stableSymbols.includes(pool.token0.symbol)
+      const token1IsStable = stableSymbols.includes(pool.token1.symbol)
+
+      if (token1IsStable) {
+         // token1 is stablecoin → token1 = $1, derive token0
+         price1USD = 1
+         price0USD = currentPrice // currentPrice is "token1 per token0" = "USD per token0"
+      } else if (token0IsStable) {
+         // token0 is stablecoin → token0 = $1, derive token1
+         price0USD = 1
+         price1USD = 1 / currentPrice // invert to get USD per token1
+      } else {
+         // No stablecoin, inference failed → return 0 (will show "N/A")
+         console.warn("Price inference failed and no stablecoin detected", {
+            pool: pool.id,
+            price0USD,
+            price1USD,
+            tvlUSD,
+            currentPrice
+         })
+         return { token0PriceUSD: 0, token1PriceUSD: 0 }
+      }
+   }
+
+   return { token0PriceUSD: price0USD, token1PriceUSD: price1USD }
+}

--- a/src/utils/calculateTokenRatio.js
+++ b/src/utils/calculateTokenRatio.js
@@ -1,0 +1,48 @@
+import { priceToTick, getTickSpacing, alignTickToSpacing } from "./uniswapV3Ticks"
+
+/**
+ * Calculates token ratio based on assumed price inside a range
+ * @param {number} assumedPrice - Base price to calculate from
+ * @param {number} minPrice - Lower bound of the range
+ * @param {number} maxPrice - Upper bound of the range
+ * @param {number} feeTier - Fee tier (100, 500, 3000 or 10000) 
+ * @returns {{ token0Percent: number, token1Percent: number }}
+ */
+export function calculateTokenRatio(
+   assumedPrice,
+   minPrice,
+   maxPrice,
+   feeTier
+) {
+   // 1. validate inputs (edge cases)
+   if (assumedPrice <= minPrice) {
+      return { token0Percent: 100, token1Percent: 0 }
+   }
+   if (assumedPrice >= maxPrice) {
+      return { token0Percent: 0, token1Percent: 100 }
+   }
+   if (minPrice === maxPrice) {
+      return { token0Percent: 50, token1Percent: 50 }
+   }
+
+   // 2. convert prices to ticks
+   const tickCurrent = priceToTick(assumedPrice)
+   const tickLower = priceToTick(minPrice)
+   const tickUpper = priceToTick(maxPrice)
+
+   // 3. align ticks to spacing
+   const tickSpacing = getTickSpacing(feeTier)
+
+   const alignedCurrent = alignTickToSpacing(tickCurrent, tickSpacing)
+   const alignedLower = alignTickToSpacing(tickLower, tickSpacing)
+   const alignedUpper = alignTickToSpacing(tickUpper, tickSpacing)
+
+   // 4. calculate ratio [0, 1]
+   const ratio = (alignedCurrent - alignedUpper) / (alignedLower - alignedUpper)
+
+   // 5. convert to percentages with simple rounding
+   const token0Percent = Math.round(ratio * 100 * 100) / 100
+   const token1Percent = Math.round((1 - ratio) * 100 * 100) / 100
+
+   return { token0Percent, token1Percent }
+}

--- a/src/utils/formatPoolHourData.js
+++ b/src/utils/formatPoolHourData.js
@@ -1,0 +1,44 @@
+/**
+ * Transforms raw poolHourDatas from The Graph into calculation-ready format
+ * @param {Array} rawData - Array of poolHourDatas objects from API
+ * @returns {Object} { hourlyData, stats }
+ */
+export function formatPoolHourData(rawData) {
+   if (!rawData || rawData.length === 0) {
+      return { hourlyData: [], stats: null }
+   }
+
+   const hourlyData = rawData.map(hour => ({
+      timestamp: hour.periodStartUnix,
+      date: new Date(hour.periodStartUnix * 1000), // for display
+      token0Price: parseFloat(hour.token0Price),
+      token1Price: parseFloat(hour.token1Price),
+      feesUSD: parseFloat(hour.feesUSD),
+      liquidity: parseFloat(hour.liquidity),
+      tvlUSD: parseFloat(hour.tvlUSD),
+      sqrtPrice: hour.sqrtPrice, // Keep as string (Q64.96 format, rarely needed)
+      tick: parseInt(hour.tick)
+   }))
+
+   const stats = {
+      dataPoints: hourlyData.length,
+      daysOfData: Math.floor(hourlyData.length / 24),
+      startDate: hourlyData[0].date,
+      endDate: hourlyData[hourlyData.length - 1].date,
+      minPrice: Math.min(...hourlyData.map(h => h.token0Price)),
+      maxPrice: Math.min(...hourlyData.map(h => h.token1Price)),
+      medianPrice: calculateMedian(hourlyData.map(h => h.token0Price)),
+      totalFeesUSD: hourlyData.reduce((acc, curr) => acc + curr.feesUSD, 0)
+   }
+
+   return { hourlyData, stats }
+}
+
+function calculateMedian(arr) {
+   const sorted = [...arr].sort((a, b) => a - b)
+   const mid = Math.floor(sorted.length / 2)
+   
+   return sorted.length % 2 === 0
+      ? (sorted[mid - 1] + sorted[mid]) / 2
+      : sorted[mid]
+}

--- a/src/utils/formatPoolHourData.js
+++ b/src/utils/formatPoolHourData.js
@@ -26,7 +26,7 @@ export function formatPoolHourData(rawData) {
       startDate: hourlyData[0].date,
       endDate: hourlyData[hourlyData.length - 1].date,
       minPrice: Math.min(...hourlyData.map(h => h.token0Price)),
-      maxPrice: Math.min(...hourlyData.map(h => h.token1Price)),
+      maxPrice: Math.max(...hourlyData.map(h => h.token1Price)),
       medianPrice: calculateMedian(hourlyData.map(h => h.token0Price)),
       totalFeesUSD: hourlyData.reduce((acc, curr) => acc + curr.feesUSD, 0)
    }

--- a/src/utils/simulateRangePerformance.js
+++ b/src/utils/simulateRangePerformance.js
@@ -1,0 +1,335 @@
+import { assessDataQuality } from "./assessDataQuality"
+
+export function simulateRangePerformance({
+   capitalUSD,
+   minPrice,
+   maxPrice,
+   fullRange,
+   selectedTokenIdx,
+   hourlyData,
+   pool
+}) {
+   // ===== STAGE 1: BASIC VALIDATIONS =====
+   if (!hourlyData?.length || hourlyData.length < 168) {
+      return { success: false, error: "No hourly data" }
+   }
+
+   if (capitalUSD < 10) {
+      return { success: false, error: "Capital must be at least $10"}
+   }
+   
+   if (!fullRange) {
+      if (minPrice == null || maxPrice == null) {
+         return { 
+            success: false, 
+            error: "Price range required when Full Range is off" 
+         }
+      }
+      if (minPrice <= 0 || maxPrice <= 0) {
+         return { success: false, error: "Prices must be positive" }
+      }
+      if (minPrice >= maxPrice) {
+         return { 
+            success: false, 
+            error: "Min Price must be lower than Max Price" 
+         }
+      }
+   }
+
+   if (selectedTokenIdx !== 0 && selectedTokenIdx !== 1) {
+      return { success: false, error: "You must select a token"}
+   }
+
+   
+   // ===== STAGE 2: DATA QUALITY ASSESSMENT =====
+   const { quality, warnings } = assessDataQuality(hourlyData)
+   
+   
+   // ===== STAGE 3: BLOCKING DECISION =====
+   // If quality ===== "INSUFFICIENT" → return error
+   if (quality === "INSUFFICIENT") {
+      return { 
+         success: false, 
+         error: "Pool needs 7+ days of data",
+         quality
+      }
+   }
+   
+   // ===== STAGE 4: LIQUIDITY CALCULATION =====
+   // 4.1 Validate pool metadata
+   if (!pool?.totalValueLockedToken0 || !pool?.totalValueLockedToken1) {
+      return {
+         success: false,
+         error: "Pool metadata incomplete. Cannot calculate liquidity.",
+         dataQuality: quality
+      }
+   }
+
+   // 4.2 Get current price from first hourly snapshot
+   const currentPrice = hourlyData[0].token0Price
+
+   // 4.3 Calculate USD prices using inference formula
+   const priceToken0InUSD = pool.totalValueLockedUSD /
+      (pool.totalValueLockedToken0 + pool.totalValueLockedToken1 / currentPrice)
+   const priceToken1InUSD = priceToken0InUSD / currentPrice
+
+   // 4.3.1 Validate calculated prices
+   if (pool.totalValueLockedUSD <= 0) {
+      return {
+         success: false,
+         error: "Pool has no liquidity (TVL = $0)",
+         dataQuality: quality
+      }
+   }
+
+   if (pool.totalValueLockedToken0 <= 0 || pool.totalValueLockedToken1 <= 0) {
+      return {
+         success: false,
+         error: "Pool is imbalanced (one token at 0%). Cannot calculate prices.",
+         dataQuality: quality
+      }
+   }
+
+   if (priceToken0InUSD <= 0 || priceToken1InUSD <= 0 || 
+      !isFinite(priceToken0InUSD) || !isFinite(priceToken1InUSD)) {
+         return {
+            success: false,
+            error: "Invalid price calculation. Pool data may be corrupted",
+            dataQuality: quality
+         }
+   }
+
+   // 4.4 Split capital 50/50 and convert to token amounts
+   const capitalPerToken = capitalUSD / 2
+   const amount0 = capitalPerToken / priceToken0InUSD
+   const amount1 = capitalPerToken / priceToken1InUSD
+
+   // 4.5 Determine effective range (handle fullRange case)
+   let effectiveMin
+   let effectiveMax
+   
+   if (fullRange) {
+      const allPrices = hourlyData.map(h => h.token0Price)
+      const minPrice = Math.min(...allPrices)
+      const maxPrice = Math.max(...allPrices)
+      const priceRange = maxPrice - minPrice
+      const volatility = priceRange / minPrice
+
+      const bufferMultiplier = volatility < 0.2 ? 0.3 :
+                              volatility < 0.5 ? 0.5 :
+                              1.0
+      effectiveMin = minPrice * (1 - bufferMultiplier)
+      effectiveMax = maxPrice * (1 + bufferMultiplier)                 
+   } else {
+      effectiveMin = minPrice
+      effectiveMax = maxPrice
+   }
+
+   // 4.6 Calculate user liquidity using Poolfish formula
+   const sqrtPriceUpper = Math.sqrt(effectiveMax)
+   const sqrtPriceLower = Math.sqrt(effectiveMin)
+
+   let L_user
+
+   if (selectedTokenIdx === 0) {
+      L_user = amount0 * Math.sqrt(currentPrice) / (sqrtPriceUpper - sqrtPriceLower)
+   } else {
+      L_user = amount1 / (sqrtPriceUpper - sqrtPriceLower)
+   }
+
+   
+   // ===== STAGE 5: FEE ACCUMULATION LOOP =====
+   // 5.0 Pre-loop validations
+   if (L_user <= 0 || !isFinite(L_user)) {
+      return {
+         success: false,
+         error: "Invalid liquidity calculation",
+         dataQuality: quality
+      }
+   }
+   // Sanity check: your initial liquidity shouldn't exceed pool's liquidity
+   if (L_user > hourlyData[0].liquidity) {
+      warnings.push("Your position would be larger than initial pool liquidity")
+   }
+   
+   const MAX_WARNINGS = 5
+
+   // 5.1 Initialize accumulators
+   let totalFeesUSD = 0
+   let hoursInRange = 0
+   
+   // 5.2 Loop through hourly data
+   for (let i = 0; i < hourlyData.length; i++) {
+      const hour = hourlyData[i]
+
+      // 5.3 Validate hour data (skip corrupted/incomplete hours)
+      if (hour.token0Price == null || hour.liquidity == null || 
+         hour.feesUSD == null) {
+            continue
+      }
+
+      if (hour.token0Price <= 0 || hour.liquidity <= 0 || 
+         hour.feesUSD <= 0) {
+         continue
+      }
+
+      // 5.4 Check if price is in-range
+      const priceInRange = hour.token0Price >= effectiveMin &&
+                           hour.token0Price <= effectiveMax
+      
+      if (!priceInRange) {
+         continue // Skip out-of-range hours
+      }
+
+      // 5.5 Calculate fee share
+      const L_total = hour.liquidity
+
+      // Edge Case 1: Skip if pool is empty
+      if (L_total === 0) {
+         continue
+      }
+
+      // Edge Case 2: Cap fee share at 100%
+      const rawFeeShare = L_user / L_total
+      const feeShare = Math.min(L_user / L_total, 1.0)
+
+      if (rawFeeShare > 1) {
+         warnings.push(`High liquidity share (${(rawFeeShare * 100).toFixed(1)}%) detected at hour ${i}. Pool may be unstable.`)
+      }
+
+      if (rawFeeShare > 0.5 && warnings.length < MAX_WARNINGS) {
+         warnings.push(`High liquidity share (${(rawFeeShare * 100).toFixed(1)}%) detected at hour ${i}`)
+      }
+
+      // 5.6 Accumulate fees
+      totalFeesUSD += hour.feesUSD * feeShare
+      hoursInRange++
+   }
+
+   if (warnings.length === MAX_WARNINGS) {
+      warnings.push(`... and ${hoursInRange - MAX_WARNINGS} more anomalies. Pool data may be unstable.`)
+   }
+
+   // 5.7 Check if position was ever in-range
+   if (hoursInRange === 0) {
+      const actualPriceRange = {
+         min: Math.min(...hourlyData.map(h => h.token0Price)),
+         max: Math.min(...hourlyData.map(h => h.token0Price))
+      }
+
+      return {
+         success: false,
+         error: `Price never entered range (${effectiveMin.toFixed(2)}-${effectiveMax.toFixed(2)}). Actual range: ${actualPriceRange.min.toFixed(2)}-${actualPriceRange.max.toFixed(2)}`,
+         dataQuality: quality
+      }
+   }
+
+   // 5.8 Calculate summary stats
+   const percentInRange = (hoursInRange / hourlyData.length) * 100
+
+   // 5.9 Adjust data quality based on anomalies
+   let finalQuality = quality // Start with Stage 2 assessment
+   const anomalyRate = warnings.length / hourlyData.length
+
+   if (anomalyRate > 0.5) {
+      finalQuality = "INSUFFICIENT"
+   } else if (anomalyRate > 0.2) {
+      finalQuality = quality === "EXCELENT" ? "RELIABLE" :
+                     quality === "RELIABLE" ? "INSUFFICIENT" :
+                     quality // Already LIMITED or INSUFFICIENT
+   }
+
+   // add meta-warning if quality drops
+   if (finalQuality !== quality) {
+      warnings.unshift(`⚠️ Data quality downgraded to ${finalQuality} due to ${warnings.length} anomalies`)
+   }
+   
+   // ===== STAGE 6: IL CALCULATION =====
+   // 6.1 Get price endpoints
+   const initialPrice = hourlyData[0].token0Price
+   const finalPrice = hourlyData[hourlyData.length - 1].token0Price
+
+   // 6.2 Validate price data
+   if (initialPrice <= 0 || finalPrice <= 0) {
+      return {
+         success: false,
+         error: "Invalid price data for IL calculation",
+         dataQuality: quality
+      }
+   }
+
+   // 6.3 Calculate IL using AMM formula (independent of token types)
+   const priceRatio = finalPrice / initialPrice
+
+   // Classic IL formula: 2 × √(ratio) / (1 + ratio) - 1
+   const IL_decimal = (2 * Math.sqrt(priceRatio)) / (1 + priceRatio - 1)
+   const IL_percent = IL_decimal * 100
+
+   // 6.4 Add disclaimer for concentrated ranges
+   if (!fullRange) {
+      warnings.push("IL calculated using full-range formula. Actual IL may be lower for concentrated positions.")
+   }
+
+
+   // ===== STAGE 7: APR CALCULATION =====
+
+   // 7.1 Calculate time period
+   const daysOfData = hourlyData.length / 24
+
+   // 7.2 Calculate APR (annualized fee return)
+   const feeReturnPercent = (totalFeesUSD / capitalUSD) * 100
+   const APR = feeReturnPercent * (365 / daysOfData)
+
+   // 7.3 Simplified hold value (assume price changes, quantities stay same)
+   // Use current pool TVL to infer prices (best approximation without historical TVL)
+   const initialAmount0 = amount0
+   const initialAmount1 = amount1
+
+   const finalPriceToken0InUSD = pool.totalValueLockedUSD / 
+      (pool.totalValueLockedToken0 + pool.totalValueLockedToken1 / finalPrice)
+   const finalPriceToken1InUSD = finalPriceToken0InUSD / finalPrice
+
+   const holdValue = (initialAmount0 * finalPriceToken0InUSD) +
+                     (initialAmount1 * finalPriceToken1InUSD)
+
+   warnings.push("Hold value uses current pool TVL for price inference. Minor inaccuracy possible")
+   
+   // 7.4 Calculate LP position value (with IL)
+   const lpValue = capitalUSD * (1 + IL_decimal)
+
+   // 7.5 Calculate net P&L (fees - IL)
+   const netPnL = totalFeesUSD + (lpValue - capitalUSD)
+   const netPnlPercent = (netPnL / capitalUSD) * 100
+
+   // 7.6 Calculate hold P&L for comparison
+   const holdPnL = holdValue - capitalUSD
+   const holdPnLPercent = (holdPnL / capitalUSD) * 100
+
+   return { 
+      success: true,
+
+      // Fee metrics
+      totalFeesUSD,
+      feeReturnPercent,
+      APR,
+
+      // Range metrics
+      hoursInRange,
+      percentInRange,
+
+      // IL metrics
+      IL_percent,
+
+      // P&L comparison
+      lpValue,
+      holdValue,
+      netPnL,
+      netPnlPercent,
+      holdPnL,
+      holdPnLPercent,
+
+      // Meta
+      dataQuality: finalQuality,
+      warnings: warnings.slice(0, MAX_WARNINGS)
+   }
+}

--- a/src/utils/simulateRangePerformance.js
+++ b/src/utils/simulateRangePerformance.js
@@ -1,6 +1,7 @@
 import { assessDataQuality } from "./assessDataQuality"
 import { calculateTokenRatio } from "./calculateTokenRatio"
 import { calculateLiquidity } from "./calculateLiquidity"
+import { calculateIL } from "./calculateIL"
 
 export function simulateRangePerformance({
    capitalUSD,
@@ -407,11 +408,8 @@ export function simulateRangePerformance({
       }
    }
 
-   // 6.3 Calculate IL using AMM formula (independent of token types)
-   const priceRatio = finalPrice / initialPrice
-
    // Classic IL formula: 2 × √(ratio) / (1 + ratio) - 1
-   const IL_decimal = (2 * Math.sqrt(priceRatio)) / (1 + priceRatio) - 1
+   const IL_decimal = calculateIL(initialPrice, finalPrice)
    const IL_percent = IL_decimal * 100
 
 

--- a/src/utils/uniswapV3Ticks.js
+++ b/src/utils/uniswapV3Ticks.js
@@ -1,0 +1,85 @@
+/**
+ * Uniswap V3 tick math utilities
+ * Reference: https://docs.uniswap.org/contracts/v3/reference/core/libraries/TickMath
+ */
+
+// Uniswap V3 tick limits
+const MIN_TICK = -887272
+const MAX_TICK = 887272
+
+/**
+ * Mapping from fee tier (in hundreds of bps) to tick spacing
+ * @type {Object.<number, number>}
+ */
+const FEE_TIER_TO_TICK_SPACING = {
+   100: 1,      // 0.01% fee
+   500: 10,     // 0.05% fee
+   3000: 60,    // 0.30% fee
+   10000: 200   // 1.00% fee
+}
+
+/**
+ * Convert price to tick index
+ * @param {number} price - Price value (token1/token0)
+ * @returns {number} - Tick index
+ */
+export function priceToTick(price) {
+   if (price <= 0) return MIN_TICK
+
+   // Formula: tick = floor(log(price) / log(1.0001))
+   const tick = Math.floor(Math.log(price) / Math.log(1.0001))
+
+   // Clamp to valid range
+   return Math.max(MIN_TICK, Math.min(MAX_TICK, tick))
+}
+
+/**
+ * Convert tick index to price
+ * @param {number} tick - Tick index
+ * @returns {number} - Price value
+ */
+export function tickToPrice(tick) {
+   // Formula: price = 1.0001^tick
+   return Math.pow(1.0001, tick)
+}
+
+/**
+ * Get tick spacing for a given fee tier
+ * @param {number} feeTier - Fee tier (100, 500, 3000 or 10000)
+ * @returns {number} - Tick spacing
+ */
+export function getTickSpacing(feeTier) {
+   return FEE_TIER_TO_TICK_SPACING[feeTier] || 60 // Default to 0.3% spacing
+}
+
+/**
+ * Round tick to nearest valid tick based on spacing
+ * @param {number} tick - Raw tick
+ * @param {number} tickSpacing - Tick spacing for the pool
+ * @returns {number} - Aligned tick
+ */
+export function alignTickToSpacing(tick, tickSpacing) {
+   return Math.round(tick / tickSpacing) * tickSpacing
+}
+
+/**
+ * Increment price by N tick spacings
+ * @param {number} currentPrice - Current price
+ * @param {number} feeTier - Pool fee tier (100, 500, 30000, 10000)
+ * @param {number} direction - 1 for increment, -1 for decrement
+ * @returns {number} New price
+ */
+export function incrementPriceByTick(currentPrice, feeTier, direction = 1) {
+   const tickSpacing = getTickSpacing(feeTier)
+   const currentTick = priceToTick(currentPrice)
+   
+   // Align to nearest valid tick first (hanldes manual input edge cases)
+   const alignedTick = alignTickToSpacing(currentTick, tickSpacing)
+   
+   // Move by one spacing unit
+   const newTick = alignedTick + (direction * tickSpacing)
+   
+   // Clamp and convert back to price
+   const clampedTick = Math.max(MIN_TICK, Math.min(MAX_TICK, newTick))
+   return tickToPrice(clampedTick)
+}


### PR DESCRIPTION
## Add Range Calculator Feature

Built a tool to simulate Uniswap V3 concentrated liquidity positions using historical data from TheGraph.

### What it does
- Calculates fees based on liquidity contribution (accounts for concentration advantage)
- Compares LP strategy vs HODL strategy with IL calculations
- Projects future performance based on user-defined price scenarios
- Shows data quality warnings for pools with insufficient history

### Implementation notes
The main challenge was handling on-chain liquidity normalization. 
TheGraph returns values scaled by token decimals (e.g., `10^18` for WETH), which exceed JavaScript's safe integer limit. 
Solution: Use `BigInt` for parsing, then normalize using geometric mean of token decimals before calculations.

Fee accumulation uses hourly snapshots to calculate dynamic fee shares:
```js
feeShare = L_user / (L_user + L_pool_normalized)
totalFeesUSD += hourFeesUSD * feeShare
```

Also added a "days to break even" metric that estimates how long fees need to accumulate to offset IL.

### Files changed
- **Core logic:** `simulateRangePerformance.js`, `calculateLiquidity.js`, `calculateIL.js`
- **Hooks:** `useProjectionCalculator.js` (future scenarios)
- **Docs:** `FEE_CALCULATION.md` (explains math)

### Limitations
- Hourly granularity (not per-block)
- Static token amounts (doesn't simulate rebalancing)
- Linear fee projection (ignores volume volatility)
