### PR TITLE
feat: header tooltips for APY, TVL, and Vol (24h) columns

### DIFF
--- a/src/components/pools/PoolTable.jsx
+++ b/src/components/pools/PoolTable.jsx
@@ -214,25 +214,39 @@ const PoolTable = forwardRef(
         <tr key={hg.id}>
           {hg.headers.map((header) => {
             const isSticky = header.column.columnDef.meta?.isSticky
+            const tooltipText = header.column.columnDef.meta?.tooltip
 
             return (
               <th
                 key={header.id}
                 onClick={header.column.getToggleSortingHandler()}
                 style={{ width: header.column.getSize() }}
-                className={`sticky top-0 z-10 bg-base-300 px-6 py-4 text-center text-xs font-semibold text-base-content/50 uppercase tracking-wider cursor-pointer hover:bg-base-300 transition
-                        ${isSticky ? 'left-0 z-11 pl-4 text-left sticky-column-shadow' : ''}
-                     `.trim()}
+                className={`sticky top-0 z-10 bg-base-300 px-6 py-4 text-xs font-semibold text-base-content/50 uppercase tracking-wider cursor-pointer hover:bg-base-300 transition
+                  ${isSticky ? 'left-0 z-11 pl-4 text-left sticky-column-shadow' : ''}
+                `.trim()}
               >
-                {flexRender(
-                  header.column.columnDef.header,
-                  header.getContext()
-                )}
-                {header.column.getIsSorted() && (
-                  <span className="ml-1">
-                    {header.column.getIsSorted() === 'desc' ? '↓' : '↑'}
-                  </span>
-                )}
+                <div className={`flex items-center gap-1 ${isSticky ? 'justify-start' : 'justify-center'}`}>
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext()
+                  )}
+
+                  {header.column.getIsSorted() && (
+                    <span>
+                      {header.column.getIsSorted() === 'desc' ? '↓' : '↑'}
+                    </span>
+                  )}
+
+                  {tooltipText &&
+                    <span
+                      className="tooltip tooltip-bottom text-sm text-base-content/50"
+                      data-tip={tooltipText}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      ⓘ
+                    </span>
+                  }
+                </div>
               </th>
             )
           })}

--- a/src/components/pools/PoolTable.jsx
+++ b/src/components/pools/PoolTable.jsx
@@ -221,11 +221,13 @@ const PoolTable = forwardRef(
                 key={header.id}
                 onClick={header.column.getToggleSortingHandler()}
                 style={{ width: header.column.getSize() }}
-                className={`sticky top-0 z-10 bg-base-300 px-6 py-4 text-xs font-semibold text-base-content/50 uppercase tracking-wider cursor-pointer hover:bg-base-300 transition
+                className={`sticky top-0 z-10 has-[.tooltip:hover]:z-20 bg-base-300 px-6 py-4 text-xs font-semibold text-base-content/50 uppercase tracking-wider cursor-pointer hover:bg-base-300 transition
                   ${isSticky ? 'left-0 z-11 pl-4 text-left sticky-column-shadow' : ''}
                 `.trim()}
               >
-                <div className={`flex items-center gap-1 ${isSticky ? 'justify-start' : 'justify-center'}`}>
+                <div className={`flex items-center gap-1 whitespace-nowrap
+                  ${isSticky ? 'justify-start' : 'justify-center'}`}
+                >
                   {flexRender(
                     header.column.columnDef.header,
                     header.getContext()

--- a/src/data/tableColumns.js
+++ b/src/data/tableColumns.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {Object} ColumnMeta
  * @property {"both" | "desktop" | "mobile"} showOn - Determines device visibility for the column
+ * @property {string} [tooltip] - Tooltip text to be shown on table header cells
  * @property {boolean} [isSticky] - Indicates if column should remain fixed during horizontal scrolling
  */
 
@@ -9,7 +10,7 @@
  * @property {string} [accessorKey] - Data key used to retrieve value for this column
  * @property {string} [id] - Unique identifier for column (required if accessorKey not provided)
  * @property {string} header - Display text for column header
- * @property {ColumnMeta} - meta - Additional metadata for UI configuration and visibility logic
+ * @property {ColumnMeta} meta - Additional metadata for UI configuration and visibility logic
  */
 
 /**
@@ -27,17 +28,26 @@ export const baseColumns = [
   {
     accessorKey: 'apyBase',
     header: 'APY',
-    meta: { showOn: 'both' }
+    meta: {
+      showOn: 'both',
+      tooltip: "Annualized Yield based on generated fees in the last 24h"
+    }
   },
   {
     accessorKey: 'tvlUsd',
     header: 'TVL',
-    meta: { showOn: 'both' }
+    meta: {
+      showOn: 'both',
+      tooltip: "Total Value Locked - Total liquidity accumulated in the pool"
+    }
   },
   {
     accessorKey: 'volumeUsd1d',
     header: 'Vol (24h)',
-    meta: { showOn: 'both' }
+    meta: {
+      showOn: 'both',
+      tooltip: "Total swap volume for the pool in the last 24 hours"
+    }
   },
   {
     accessorKey: 'sparklineIn7d',


### PR DESCRIPTION
## What
Adds contextual info icons to ambiguous column headers in the pools table.

## Why
DeFi-specific terms like TVL and APY might not be universally understood.
Inline tooltips reduce friction without cluttering the UI.

## Changes
- Added optional `tooltip`field to `columnMeta`type and populated it for APY, TVL, and Vol (24h) columns
- Rendered ⓘ icon inside `<th>` with DaisyUI tooltip on hover
- `stopPropagation` on icon click to prevent unintended sort triggers
- Flex alignment on header content adjusted per column type (sticky vs centered)

## Fixes:
- Added `whitespace-nowrap` on all headers
- Fixed tooltip clipped by sticky `<th>` stacking context using `has-[.tooltip:hover]:z-20` 