### PR TITLE
feat(pool-filters): filter bar redesign

### DIFF
--- a/src/components/pools/PoolFilters.jsx
+++ b/src/components/pools/PoolFilters.jsx
@@ -45,58 +45,39 @@ export function PoolFilters({
   }
 
   return (
-    <div className="flex flex-wrap gap-2 mb-4 p-4 bg-base-100">
-      <label className="form-control max-w-xs">
-        <div className="label">
-          <span className="label-text">Coin/Pair</span>
-        </div>
-        <input
-          type="text"
-          placeholder="SOL or SOL/USDC"
-          value={localFilters.search}
-          className="input input-bordered input-sm rounded-xl"
-          onChange={(e) => updateLocalFilter('search', e.target.value)}
-        />
-      </label>
-
-      <label className="form-control w-full max-w-xs">
-        <div className="label">
-          <span className="label-text">Platform</span>
-        </div>
+    <div className="flex flex-col md:flex-row gap-2 mb-4 p-4 bg-base-100">
+      {/* TODO: mobile toggle — commit 3 */}
+      <input
+        type="text"
+        placeholder="SOL or SOL/USDC"
+        value={localFilters.search}
+        className="input input-bordered input-sm rounded-xl"
+        onChange={(e) => updateLocalFilter('search', e.target.value)}
+      />
+      <div className="hidden md:flex whitespace-nowrap">
         <Dropdown
           selected={filters.platforms}
           onToggle={togglePlatform}
           options={availablePlatforms}
         />
-      </label>
-
-      <label className="form-control w-full max-w-xs">
-        TVL
-        <input
-          type="number"
-          placeholder="Min TVL ($)"
-          value={localFilters.tvlUsd}
-          className="input input-bordered input-sm rounded-xl"
-          onChange={(e) => updateLocalFilter('tvlUsd', e.target.value)}
-        />
-      </label>
-
-      <label className="form-control w-full max-w-xs">
-        Vol (24h)
-        <input
-          type="number"
-          placeholder="Min 24h Vol ($)"
-          value={localFilters.volumeUsd1d}
-          className="input input-bordered input-sm rounded-xl"
-          onChange={(e) => updateLocalFilter('volumeUsd1d', e.target.value)}
-        />
-      </label>
-
-      <div className="flex items-end">
-        <button onClick={handleClearFilters} className="btn btn-sm btn-ghost">
-          Clear
-        </button>
       </div>
+      <input
+        type="number"
+        placeholder="Min TVL ($)"
+        value={localFilters.tvlUsd}
+        className="hidden md:block input input-bordered input-sm rounded-xl"
+        onChange={(e) => updateLocalFilter('tvlUsd', e.target.value)}
+      />
+      <input
+        type="number"
+        placeholder="Min Vol 24h ($)"
+        value={localFilters.volumeUsd1d}
+        className="hidden md:block input input-bordered input-sm rounded-xl"
+        onChange={(e) => updateLocalFilter('volumeUsd1d', e.target.value)}
+      />
+      <button onClick={handleClearFilters} className="hidden md:block btn btn-sm btn-ghost">
+        Clear
+      </button>
     </div>
   )
 }

--- a/src/components/pools/PoolFilters.jsx
+++ b/src/components/pools/PoolFilters.jsx
@@ -47,10 +47,17 @@ export function PoolFilters({
     clearFilters()      // 2. Clear URL (Effect 1 will skip one cycle)
   }
 
+  const activeCount = [
+    filters.search !== '',
+    filters.platforms.length > 0,
+    filters.tvlUsd !== '',
+    filters.volumeUsd1d !== ''
+  ].filter(Boolean).length
+
   return (
     <div className="flex flex-col md:flex-row gap-2 mb-4 p-4 bg-base-100">
       {/* Mobile row: search + toggle */}
-      <div className="flex gap-2">
+      <div className="flex gap-2 grow">
         <input
           type="text"
           placeholder="SOL or SOL/USDC"
@@ -63,6 +70,11 @@ export function PoolFilters({
           className="btn btn-sm btn-outline md:hidden rounded-xl"
         >
           Filters
+          <span
+            className={`${activeCount < 1 ? 'hidden' : 'badge badge-xs badge-primary'}`}
+          >
+            {activeCount}
+          </span>
         </button>
       </div>
 
@@ -76,19 +88,50 @@ export function PoolFilters({
       {/* Bottom sheet */}
       <div
         className={`fixed bottom-0 left-0 right-0 z-50 md:hidden bg-base-100
-          rounded-t-2xl transition-transform duration-300 ease-out
+          rounded-t-4xl transition-transform duration-300 ease-out
           ${isOpen ? 'translate-y-0' : 'translate-y-full'}`}
       >
         <div className="p-4">
           <div className="w-12 h-1 bg-base-300 rounded-full mx-auto mb-4" />
           <button
-            className="btn btn-ghost absolute top-4 right-4"
+            className="btn btn-ghost absolute top-4 right-4 mb-4"
             onClick={() => {setIsOpen(false)}}
           >
             ✕
           </button>
+
+          {/* Desktop row: dropdown + tvl + vol + clear */}
+            <div className="whitespace-nowrap mt-10 p-2">
+              <Dropdown
+                selected={filters.platforms}
+                onToggle={togglePlatform}
+                options={availablePlatforms}
+              />
+            </div>
+
+            <div className="flex flex-col sm:flex-row flex-wrap flex-1 p-2 gap-6 sm:gap-4 my-2">
+              <input
+                type="number"
+                placeholder="Min TVL ($)"
+                value={localFilters.tvlUsd}
+                className="input sm:flex-1 w-full input-bordered input-sm rounded-xl"
+                onChange={(e) => updateLocalFilter('tvlUsd', e.target.value)}
+              />
+
+              <input
+                type="number"
+                placeholder="Min Vol 24h ($)"
+                value={localFilters.volumeUsd1d}
+                className="input sm:flex-1 w-full input-bordered input-sm rounded-xl"
+                onChange={(e) => updateLocalFilter('volumeUsd1d', e.target.value)}
+              />
+
+              <button onClick={handleClearFilters} className="btn btn-sm btn-ghost">
+                Clear filters
+              </button>
+            </div>
+
         </div>
-        {/* TODO: filters — commit 4 */}
       </div>
 
       <div className="hidden md:flex whitespace-nowrap">
@@ -98,25 +141,27 @@ export function PoolFilters({
           options={availablePlatforms}
         />
       </div>
-
       <input
         type="number"
         placeholder="Min TVL ($)"
         value={localFilters.tvlUsd}
-        className="hidden md:block input input-bordered input-sm rounded-xl"
+        className="hidden md:block input input-bordered input-sm rounded-xl w-36"
         onChange={(e) => updateLocalFilter('tvlUsd', e.target.value)}
       />
-
       <input
         type="number"
         placeholder="Min Vol 24h ($)"
         value={localFilters.volumeUsd1d}
-        className="hidden md:block input input-bordered input-sm rounded-xl"
+        className="hidden md:block input input-bordered input-sm rounded-xl w-36"
         onChange={(e) => updateLocalFilter('volumeUsd1d', e.target.value)}
       />
-
       <button onClick={handleClearFilters} className="hidden md:block btn btn-sm btn-ghost">
         Clear filters
+        <span
+          className={`ml-2 ${activeCount < 1 ? 'hidden' : 'badge badge-xs badge-primary'}`}
+        >
+          {activeCount}
+        </span>
       </button>
     </div>
   )

--- a/src/components/pools/PoolFilters.jsx
+++ b/src/components/pools/PoolFilters.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useDebouncedFilterInputs } from '../../hooks/useDebouncedFilterInputs'
 import { Dropdown } from '../common/Dropdown'
 
@@ -31,6 +32,8 @@ export function PoolFilters({
   clearFilters,
   availablePlatforms
 }) {
+  const [isOpen, setIsOpen] = useState(false)
+
   const {
     localFilters,
     updateLocalFilter,
@@ -46,14 +49,48 @@ export function PoolFilters({
 
   return (
     <div className="flex flex-col md:flex-row gap-2 mb-4 p-4 bg-base-100">
-      {/* TODO: mobile toggle — commit 3 */}
-      <input
-        type="text"
-        placeholder="SOL or SOL/USDC"
-        value={localFilters.search}
-        className="input input-bordered input-sm rounded-xl"
-        onChange={(e) => updateLocalFilter('search', e.target.value)}
+      {/* Mobile row: search + toggle */}
+      <div className="flex gap-2">
+        <input
+          type="text"
+          placeholder="SOL or SOL/USDC"
+          value={localFilters.search}
+          className="input input-bordered input-sm rounded-xl flex-1"
+          onChange={(e) => updateLocalFilter('search', e.target.value)}
+        />
+        <button
+          onClick={() => {setIsOpen(true)}}
+          className="btn btn-sm btn-outline md:hidden rounded-xl"
+        >
+          Filters
+        </button>
+      </div>
+
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 bg-black/50 z-40 md:hidden transition-opacity duration-300
+          ${isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+        onClick={() => {setIsOpen(false)}}
       />
+
+      {/* Bottom sheet */}
+      <div
+        className={`fixed bottom-0 left-0 right-0 z-50 md:hidden bg-base-100
+          rounded-t-2xl transition-transform duration-300 ease-out
+          ${isOpen ? 'translate-y-0' : 'translate-y-full'}`}
+      >
+        <div className="p-4">
+          <div className="w-12 h-1 bg-base-300 rounded-full mx-auto mb-4" />
+          <button
+            className="btn btn-ghost absolute top-4 right-4"
+            onClick={() => {setIsOpen(false)}}
+          >
+            ✕
+          </button>
+        </div>
+        {/* TODO: filters — commit 4 */}
+      </div>
+
       <div className="hidden md:flex whitespace-nowrap">
         <Dropdown
           selected={filters.platforms}
@@ -61,6 +98,7 @@ export function PoolFilters({
           options={availablePlatforms}
         />
       </div>
+
       <input
         type="number"
         placeholder="Min TVL ($)"
@@ -68,6 +106,7 @@ export function PoolFilters({
         className="hidden md:block input input-bordered input-sm rounded-xl"
         onChange={(e) => updateLocalFilter('tvlUsd', e.target.value)}
       />
+
       <input
         type="number"
         placeholder="Min Vol 24h ($)"
@@ -75,8 +114,9 @@ export function PoolFilters({
         className="hidden md:block input input-bordered input-sm rounded-xl"
         onChange={(e) => updateLocalFilter('volumeUsd1d', e.target.value)}
       />
+
       <button onClick={handleClearFilters} className="hidden md:block btn btn-sm btn-ghost">
-        Clear
+        Clear filters
       </button>
     </div>
   )

--- a/src/pages/Pools.jsx
+++ b/src/pages/Pools.jsx
@@ -20,10 +20,7 @@ export default function Pools() {
     <div className="mx-auto max-w-7xl">
       {/* SECTION: Header and context */}
       <header className="p-4">
-        <h1 className="text-3xl font-bold">Top LP Pools</h1>
-        <p className="text-gray-600">
-          Liquidity pools with real volume and APY history
-        </p>
+        <h1 className="text-3xl font-bold">Explore Pools</h1>
       </header>
 
       {/* SECTION: Data orchestration */}


### PR DESCRIPTION
## What
Redesigned the pool discovery filter bar for a more compact, mobile-first UX.

## Why
The previous layout stacked labeled inputs vertically, wasting vertical space on mobile and feeling lose on desktop. 
Filter controls should be secondary to the data, not dominate the viewport before the user sees a single pool.

## Changes
- Simplified page header copy
- Desktop: single-row filter bar with placeholder-only inputs (no labels), search input grows to fill available space
- Mobile: search + filter toggle button on one line
- Mobile: bottom sheet with slide-up animation and backdrop
- Active filter count badge on mobile toggle button and in clear filters button on desktop