### PR TITLE
feat: liquidity distribution chart

### DIFF
--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -182,6 +182,7 @@ export function PoolDetail() {
             />
           </div>
           <PoolCharts
+            pool={pool}
             history={history}
             selectedTokenIdx={selectedTokenIdx}
             tokenSymbols={tokenSymbols}

--- a/src/components/pool-detail/charts/CustomLiquidityTooltip.jsx
+++ b/src/components/pool-detail/charts/CustomLiquidityTooltip.jsx
@@ -1,0 +1,49 @@
+import { CHART_COLORS } from "../../../constants/chartColors"
+import { formatTickPrice } from "./utils/formatTickPrice"
+
+/**
+ * UI: Liquidity Distribution Tooltip (Recharts Custom Component)
+ *
+ */
+export function CustomLiquidityTooltip({
+  active,
+  payload,
+  tokenSymbols,
+  selectedTokenIdx
+}) {
+  if (!active || !payload?.length) return null
+
+  const [token0Symbol, token1Symbol] = tokenSymbols
+  const entry = payload[0]
+
+  const price = entry.payload.price
+  const label = selectedTokenIdx === 0
+    ? `${token0Symbol} per ${token1Symbol}`
+    : `${token1Symbol} per ${token0Symbol}`
+
+  return (
+    <div
+      className="rounded-lg p-3 shadow-lg border"
+      style={{
+        backgroundColor: CHART_COLORS.tooltip.bg,
+        borderColor: CHART_COLORS.tooltip.border,
+        color: CHART_COLORS.tooltip.text
+      }}
+    >
+      <p className="font-semibold mb-2">{label}</p>
+
+      <div className="flex items-center gap-2">
+        <div
+          className="w-3 h-3 rounded-full"
+          style={{ backgroundColor: entry.color }}
+        />
+        <div>
+          <span className="text-sm font-semibold">{formatTickPrice(price)}</span>
+          <span className="text-xs text-base-content/70 ml-1">
+            {label}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/pool-detail/charts/LiquidityChart.jsx
+++ b/src/components/pool-detail/charts/LiquidityChart.jsx
@@ -1,0 +1,137 @@
+import { useMemo } from 'react'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine
+} from 'recharts'
+import { CustomLiquidityTooltip } from './CustomLiquidityTooltip'
+import { usePoolTickData } from './hooks/usePoolTickData'
+import { processTickData } from './utils/processTickData'
+import { CHART_COLORS } from '../../../constants/chartColors'
+
+/**
+ * UI: Liquidity Distribution Chart
+ * Visualizes liquidity distribution for the pool against LP boundaries.
+ *
+ * @param {string} poolId - Pool contract address
+ * @param {number} currentTick - Current active tick
+ * @param {number} feeTier - Pool fee tier (100, 500, 3000, 10000 bps)
+ * @param {number} selectedTokenIdx - Index of token used for base price (0 or 1)
+ * @param {string[]} tokenSymbols - Tuple of token symbols [Symbol0, Symbol1]
+ * @param {string} token0Decimals - Amount of decimals for token0
+ * @param {string} token1Decimals - Amount of decimals for token1
+ * @param {{ minPrice, maxPrice, assumedPrice }} rangeInputs - User selected
+ *
+ * @returns {JSX.Element}
+ */
+export function LiquidityChart({
+  poolId,
+  currentTick,
+  feeTier,
+  selectedTokenIdx,
+  tokenSymbols,
+  token0Decimals,
+  token1Decimals,
+  rangeInputs,
+  currentPrice
+}) {
+  const { tickData: data, fetchError } = usePoolTickData(
+    poolId,
+    currentTick,
+    feeTier
+  )
+
+  const processedData = useMemo(() => {
+    return processTickData(data, selectedTokenIdx, token0Decimals, token1Decimals)
+  }, [data, selectedTokenIdx, token0Decimals, token1Decimals])
+
+  const yDomain = useMemo(() => {
+    if (!processedData?.length) return [0, 'auto']
+
+    const sorted = [...processedData].sort((a, b) => a.liquidity - b.liquidity)
+    const p95 = sorted[Math.floor(sorted.length * 0.95)]
+
+    return [0, p95.liquidity * 1.1] // 10% headroom above 95th percentile
+  }, [processedData])
+
+  const referencePoints = useMemo(() => {
+    if (!processedData?.length) return {}
+
+    const nearest = (target) => {
+      const scaledTarget = 1 / target
+      return processedData.reduce((best, item) =>
+        Math.abs(item.price - scaledTarget) < Math.abs(best.price - scaledTarget)
+        ? item
+        : best
+      ).price
+    }
+
+    return {
+      assumed: nearest(rangeInputs.assumedPrice || currentPrice),
+      min: nearest(rangeInputs.minPrice),
+      max: nearest(rangeInputs.maxPrice)
+    }
+  }, [processedData, rangeInputs, currentPrice])
+
+  if (fetchError || !processedData?.length) return null
+
+  return (
+    <div className="card bg-base-200 rounded-2xl">
+      <h3 className="text-lg font-semibold mb-4">Liquidity Distribution</h3>
+
+      <ResponsiveContainer
+        width="100%"
+        height={window.innerWidth < 768 ? 200 : 300}
+      >
+        <BarChart
+          data={processedData}
+          margin={{ top: 4, right: 0, bottom: 0, left: 0 }}
+        >
+          <XAxis dataKey="price" type="category" hide />
+          <YAxis hide domain={yDomain} />
+
+          {currentPrice > 0 && (
+            <ReferenceLine
+              x={referencePoints.assumed}
+              stroke={CHART_COLORS.primary}
+              strokeDasharray="5 5"
+            />
+          )}
+
+          {!rangeInputs.fullRange && (
+            <>
+              <ReferenceLine
+                x={referencePoints.min}
+                stroke={CHART_COLORS.secondary}
+                strokeDasharray= "5 5"
+              />
+              <ReferenceLine
+                x={referencePoints.max}
+                stroke={CHART_COLORS.secondary}
+                strokeDasharray= "5 5"
+              />
+            </>
+          )}
+
+          <Tooltip
+            content={
+              <CustomLiquidityTooltip
+                tokenSymbols={tokenSymbols}
+                selectedTokenIdx={selectedTokenIdx}
+              />
+            }
+          />
+          <Bar
+            dataKey="liquidity"
+            fill={CHART_COLORS.dataViz.tvl}
+            isAnimationActive={false}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/src/components/pool-detail/charts/PoolCharts.jsx
+++ b/src/components/pool-detail/charts/PoolCharts.jsx
@@ -1,5 +1,6 @@
-import { TVLVolumeChart } from './TVLVolumeChart'
+import { LiquidityChart } from './LiquidityChart'
 import { PriceChart } from './PriceChart'
+import { TVLVolumeChart } from './TVLVolumeChart'
 import { FeesApyChart } from './FeesApyChart'
 
 /**
@@ -15,6 +16,7 @@ import { FeesApyChart } from './FeesApyChart'
  * @returns {JSX.Element}
  */
 export function PoolCharts({
+  pool,
   history,
   selectedTokenIdx,
   tokenSymbols,
@@ -32,6 +34,17 @@ export function PoolCharts({
 
   return (
     <div className="grid grid-cols-1 gap-4">
+      <LiquidityChart
+        poolId={pool.id}
+        currentTick={pool.tick}
+        feeTier={pool.feeTier}
+        selectedTokenIdx={selectedTokenIdx}
+        tokenSymbols={tokenSymbols}
+        token0Decimals={pool.token0.decimals}
+        token1Decimals={pool.token1.decimals}
+        rangeInputs={rangeInputs}
+        currentPrice={currentPrice}
+      />
       <PriceChart
         history={history}
         selectedTokenIdx={selectedTokenIdx}

--- a/src/components/pool-detail/charts/hooks/usePoolTickData.js
+++ b/src/components/pool-detail/charts/hooks/usePoolTickData.js
@@ -1,11 +1,5 @@
 import { useState, useEffect } from 'react'
 import { fetchPoolTicks } from '../../../../services/theGraphClient'
-import {
-  tickToPrice,
-  priceToTick,
-  getTickSpacing,
-  alignTickToSpacing
-} from '../../calculator/utils/uniswapV3Ticks'
 
 /**
  * Custom Hook: Fetch and cache TheGraph liquidity data.
@@ -35,18 +29,7 @@ export function usePoolTickData(poolId, currentTick, feeTier) {
 
     async function loadTickData() {
       try {
-        const currentPrice = tickToPrice(currentTick)
-
-        const minPrice = currentPrice * 0.25
-        const maxPrice = currentPrice * 4
-        const rawMinTick = priceToTick(minPrice)
-        const rawMaxTick = priceToTick(maxPrice)
-
-        const tickSpacing = getTickSpacing(feeTier)
-        const alignedMinTick = alignTickToSpacing(rawMinTick, tickSpacing)
-        const alignedMaxTick = alignTickToSpacing(rawMaxTick, tickSpacing)
-
-        const data = await fetchPoolTicks(poolId, alignedMinTick, alignedMaxTick)
+        const data = await fetchPoolTicks(poolId, currentTick)
 
         if (!cancelled) {
           setTickData(data)

--- a/src/components/pool-detail/charts/hooks/usePoolTickData.js
+++ b/src/components/pool-detail/charts/hooks/usePoolTickData.js
@@ -1,0 +1,71 @@
+import { useState, useEffect } from 'react'
+import { fetchPoolTicks } from '../../../../services/theGraphClient'
+import {
+  tickToPrice,
+  priceToTick,
+  getTickSpacing,
+  alignTickToSpacing
+} from '../../calculator/utils/uniswapV3Ticks'
+
+/**
+ * Custom Hook: Fetch and cache TheGraph liquidity data.
+ *
+ * @param {string} poolId - Pool contract address
+ * @param {number} currentTick - Current active tick for reference
+ * @param {number} feeTier - Pool fee tier (100, 500, 3000, 10000 bps)
+ *
+ * @returns {{
+ *   tickData: { tick, liquidity, ticks[] },
+ *   isLoading: boolean,
+ *   fetchError: string|null
+ * }}
+ */
+export function usePoolTickData(poolId, currentTick, feeTier) {
+  const [tickData, setTickData] = useState(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [fetchError, setFetchError] = useState(null)
+
+  useEffect(() => {
+    if (!poolId || currentTick == null || !feeTier) return
+
+    setIsLoading(true)
+    setFetchError(null)
+
+    let cancelled = false
+
+    async function loadTickData() {
+      try {
+        const currentPrice = tickToPrice(currentTick)
+
+        const minPrice = currentPrice * 0.25
+        const maxPrice = currentPrice * 4
+        const rawMinTick = priceToTick(minPrice)
+        const rawMaxTick = priceToTick(maxPrice)
+
+        const tickSpacing = getTickSpacing(feeTier)
+        const alignedMinTick = alignTickToSpacing(rawMinTick, tickSpacing)
+        const alignedMaxTick = alignTickToSpacing(rawMaxTick, tickSpacing)
+
+        const data = await fetchPoolTicks(poolId, alignedMinTick, alignedMaxTick)
+
+        if (!cancelled) {
+          setTickData(data)
+          setIsLoading(false)
+        }
+      } catch (err) {
+        console.warn('❌ Fetch error:', err)
+        if (!cancelled) {
+          setFetchError(err.message)
+          setIsLoading(false)
+        }
+      }
+    }
+
+    loadTickData()
+    return () => {
+      cancelled = true
+    } // Cleanup: Prevents state update on unmounted component
+  }, [poolId, currentTick, feeTier])
+
+  return { tickData, isLoading, fetchError }
+}

--- a/src/components/pool-detail/charts/utils/formatTickPrice.js
+++ b/src/components/pool-detail/charts/utils/formatTickPrice.js
@@ -1,0 +1,34 @@
+/**
+ * Utility: Format prices from tick to currency for charts.
+ *
+ * Design Decisions:
+ *  No "$" prefix, they're denominated in terms of the selected token, not dollars.
+ *  No compact abbreviation (K/M) for prices, this might be misleading for the user.
+ *
+ * Precision:
+ *  Optimized for prices >= 1000 (e.g. 2200 -> "2,200.0")
+ *  Optimized for prices >= 0.01 (e.g. 0.058 -> "0.0580")
+ *  Optimized for prices < 0.01 (e.g. 0.0000345 -> "0.00003450")
+ */
+export function formatTickPrice(price) {
+  if (price >= 1000) {
+    return price.toLocaleString('en-US', {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1
+    })
+  }
+
+  if (price >= 0.01) {
+    return price.toLocaleString('en-US', {
+      minimumFractionDigits: 4,
+      maximumFractionDigits: 4
+    })
+  }
+
+  if (price < 0.01) {
+    return price.toLocaleString('en-US', {
+      minimumFractionDigits: 8,
+      maximumFractionDigits: 8
+    })
+  }
+}

--- a/src/components/pool-detail/charts/utils/processTickData.js
+++ b/src/components/pool-detail/charts/utils/processTickData.js
@@ -1,0 +1,57 @@
+import { tickToPrice } from "../../calculator/utils/uniswapV3Ticks"
+
+/**
+ * Process Tick Data for display in Liquidity Distribution chart (BarChart)
+ *
+ * @param {Object} tickData
+ * @param {number} tickData.tick - Current active tick
+ * @param {string} tickData.liquidity - Active liquidity at current tick (BigInt as string)
+ * @param {Object[]} tickData.ticks - Ordered tick array (up to 1000 items)
+ * @param {number} selectedTokenIdx - 0 or 1 depending on selected token scale
+ *
+ * @returns {Object[]} result
+ * @returns {number} result.price - Price at midpoint of each tick range
+ * @returns {number} result.liquidity - Active liquidity for each individual bar's range
+ */
+export function processTickData(tickData, selectedTokenIdx) {
+  if (!tickData || !tickData.ticks || tickData.ticks.length < 2) return []
+
+  const { tick: currentTick, liquidity: poolLiquidity, ticks } = tickData
+
+  // Find split point
+  const splitIdx = ticks.findIndex((t) => Number(t.tickIdx) > Number(currentTick))
+
+  if (splitIdx <= 0 || splitIdx >= ticks.length) return []
+
+  // Anchor current range
+  const liquidities = new Array(ticks.length - 1)
+  liquidities[splitIdx - 1] = parseFloat(poolLiquidity)
+
+  // Walk RIGHT: ranges above current
+  for (let i = splitIdx; i < ticks.length - 1; i++) {
+    liquidities[i] = liquidities[i - 1] + parseFloat(ticks[i].liquidityNet)
+  }
+
+  // Walk LEFT: ranges below current
+  for (let i = splitIdx - 2; i >= 0; i--) {
+    liquidities[i] = liquidities[i + 1] - parseFloat(ticks[i + 1].liquidityNet)
+  }
+
+  // Build output array
+  const result = []
+
+  for (let i = 0; i < ticks.length - 1; i++) {
+    const midTick = (Number(ticks[i].tickIdx) + Number(ticks[i + 1].tickIdx)) / 2
+    const rawPrice = tickToPrice(midTick)
+    const price = selectedTokenIdx === 0 ? rawPrice : 1 / rawPrice
+    const liquidity = Math.max(0, liquidities[i])   // clamp float precision errors
+
+    result.push({ price, liquidity })
+  }
+
+  // Sort ascending by price
+  // Natural order is ascending for token0; inversion makes it descending -> re-sort
+  result.sort((a, b) => a.price - b.price)
+
+  return result
+}

--- a/src/components/pool-detail/charts/utils/processTickData.js
+++ b/src/components/pool-detail/charts/utils/processTickData.js
@@ -13,7 +13,12 @@ import { tickToPrice } from "../../calculator/utils/uniswapV3Ticks"
  * @returns {number} result.price - Price at midpoint of each tick range
  * @returns {number} result.liquidity - Active liquidity for each individual bar's range
  */
-export function processTickData(tickData, selectedTokenIdx) {
+export function processTickData(
+  tickData,
+  selectedTokenIdx,
+  token0Decimals,
+  token1Decimals
+) {
   if (!tickData || !tickData.ticks || tickData.ticks.length < 2) return []
 
   const { tick: currentTick, liquidity: poolLiquidity, ticks } = tickData
@@ -43,7 +48,8 @@ export function processTickData(tickData, selectedTokenIdx) {
   for (let i = 0; i < ticks.length - 1; i++) {
     const midTick = (Number(ticks[i].tickIdx) + Number(ticks[i + 1].tickIdx)) / 2
     const rawPrice = tickToPrice(midTick)
-    const price = selectedTokenIdx === 0 ? rawPrice : 1 / rawPrice
+    const humanPrice = rawPrice * Math.pow(10, token0Decimals - token1Decimals)
+    const price = selectedTokenIdx === 0 ? humanPrice : 1 / humanPrice
     const liquidity = Math.max(0, liquidities[i])   // clamp float precision errors
 
     result.push({ price, liquidity })
@@ -53,5 +59,9 @@ export function processTickData(tickData, selectedTokenIdx) {
   // Natural order is ascending for token0; inversion makes it descending -> re-sort
   result.sort((a, b) => a.price - b.price)
 
-  return result
+  const firstNonZero = result.findIndex((item) => item.liquidity > 0)
+  if (firstNonZero === -1) return []
+  const lastNonZero = result.findLastIndex((item) => item.liquidity > 0)
+
+  return result.slice(firstNonZero, lastNonZero + 1)
 }

--- a/src/services/theGraphClient.js
+++ b/src/services/theGraphClient.js
@@ -152,27 +152,41 @@ const GET_POOL_HOUR_DATAS_QUERY = gql`
 /**
  * Analytical Query: Pool ticks for display in Liquidity Distribution chart
  *
- * Note: TheGraph uses BigInt! type for $minTick and $maxTick. However, we pass
- * the values as integers and let the client handle serialization.
+ * Note: TheGraph uses BigInt! type for $currentTick. However, we pass
+ * the value as integer and let the client handle serialization.
+ *
+ * Architectural Decision: Instead of using a window for displaying ticks in
+ * LiquidityChart, we split the query in ticks 'below' and ticks 'above' current
+ * tick. This way, we avoid returning a small quantity of bars in scenarios with
+ * sparse pool liquidity.
  */
 const GET_POOL_TICKS_QUERY = gql`
   query GetPoolTicks(
     $poolId: ID!,
-    $minTick: BigInt!,
-    $maxTick: BigInt!
+    $currentTick: BigInt!,
   ) {
     pool(id: $poolId) {
       tick                    # Current active tick (integer)
       liquidity
-      ticks(
-        where: { tickIdx_gte: $minTick, tickIdx_lte: $maxTick }
+      ticksBelow: ticks(
+        first: 500
+        where: { tickIdx_lt: $currentTick }
         orderBy: tickIdx
-        orderDirection: asc
-        first: 1000
+        orderDirection: desc
       ) {
         tickIdx
         liquidityNet          # Delta when price crosses this tick upward
         liquidityGross        # Total liquidity referencing this tick
+      }
+      ticksAbove: ticks(
+        first: 500
+        where: { tickIdx_gte: $currentTick }
+        orderBy: tickIdx
+        orderDirection: asc
+      ) {
+        tickIdx
+        liquidityNet
+        liquidityGross
       }
     }
   }
@@ -351,19 +365,21 @@ export async function fetchPoolHourData(poolId, startTime) {
  * Service: Fetches pool ticks for Liquidity Distribution chart in PoolCharts
  *
  * @param {string} poolId - Pool contract address (case-insensitive)
- * @param {number} minTick - Lower tick
- * @param {number} maxTick - Upper tick
+ * @param {number} currentTick - Current active tick
  *
  * @returns {Promise<Object>} result
  * @returns {number} result.tick - Current active tick
  * @returns {string} result.liquidity - Active liquidity at current tick (BigInt as string)
  * @returns {Object[]} result.ticks - Ordered tick array (up to 1000 items)
  */
-export async function fetchPoolTicks(poolId, minTick, maxTick) {
+export async function fetchPoolTicks(poolId, currentTick) {
   const data = await client.request(GET_POOL_TICKS_QUERY, {
     poolId: poolId.toLowerCase(),
-    minTick,
-    maxTick
+    currentTick
   })
-  return data.pool
+  const tick = data.pool.tick
+  const liquidity = data.pool.liquidity
+  const ticks = [...data.pool.ticksBelow.reverse(), ...data.pool.ticksAbove]
+
+  return { tick, liquidity, ticks }
 }

--- a/src/services/theGraphClient.js
+++ b/src/services/theGraphClient.js
@@ -72,6 +72,7 @@ const GET_POOL_HISTORY_QUERY = gql`
     pool(id: $poolId) {
       id
       feeTier
+      tick
       totalValueLockedToken0
       totalValueLockedToken1
       totalValueLockedUSD
@@ -149,16 +150,41 @@ const GET_POOL_HOUR_DATAS_QUERY = gql`
 `
 
 /**
+ * Analytical Query: Pool ticks for display in Liquidity Distribution chart
+ *
+ * Note: TheGraph uses BigInt! type for $minTick and $maxTick. However, we pass
+ * the values as integers and let the client handle serialization.
+ */
+const GET_POOL_TICKS_QUERY = gql`
+  query GetPoolTicks(
+    $poolId: ID!,
+    $minTick: BigInt!,
+    $maxTick: BigInt!
+  ) {
+    pool(id: $poolId) {
+      tick                    # Current active tick (integer)
+      liquidity
+      ticks(
+        where: { tickIdx_gte: $minTick, tickIdx_lte: $maxTick }
+        orderBy: tickIdx
+        orderDirection: asc
+        first: 1000
+      ) {
+        tickIdx
+        liquidityNet          # Delta when price crosses this tick upward
+        liquidityGross        # Total liquidity referencing this tick
+      }
+    }
+  }
+`
+
+/**
  * Batch Sparkline Query: Fetches 14-day trend data for multiple pools.
  *
  * Schema Note: poolDayDatas is a root-level entity (not nested under Pool).
  * We query all daily snapshots matching the pool list, then group client-side.
  *
  * Performance: 40 pools × 14 days = 560 poolDayData entities (under 1000 limit).
- *
- * @param {string[]} $poolIds - Array of pool contract addresses
- * @param {number} $startDate - Unix timestamp (14 days ago)
- * @returns {Object[]} Flat array of poolDayData entities with pool reference
  */
 const GET_POOL_SPARKLINES_QUERY = gql`
   query GetPoolSparklines($poolIds: [String!]!, $startDate: Int!) {
@@ -319,4 +345,25 @@ export async function fetchPoolHourData(poolId, startTime) {
     startTime
   })
   return data.poolHourDatas
+}
+
+/**
+ * Service: Fetches pool ticks for Liquidity Distribution chart in PoolCharts
+ *
+ * @param {string} poolId - Pool contract address (case-insensitive)
+ * @param {number} minTick - Lower tick
+ * @param {number} maxTick - Upper tick
+ *
+ * @returns {Promise<Object>} result
+ * @returns {number} result.tick - Current active tick
+ * @returns {string} result.liquidity - Active liquidity at current tick (BigInt as string)
+ * @returns {Object[]} result.ticks - Ordered tick array (up to 1000 items)
+ */
+export async function fetchPoolTicks(poolId, minTick, maxTick) {
+  const data = await client.request(GET_POOL_TICKS_QUERY, {
+    poolId: poolId.toLowerCase(),
+    minTick,
+    maxTick
+  })
+  return data.pool
 }


### PR DESCRIPTION
## What
Adds a Liquidity Distribution chart to the pool detail page showing where LPs have concentrated capital across the active price range.

## Why
Raw TVL and volume charts show historical performance but give no spatial context. A liquidity distribution chart lets users instantly see where capital is concentrated relative to their configured range, making position decisions more informed.

## Changes
- GET_POOL_TICKS_QUERY: split into ticksBelow (500, lt, desc) + ticksAbove (500, gte, asc) aliases, anchored on currentTick
- fetchPoolTicks: removed minTick/maxTick params, merges unified ticks[]
- usePoolTickData: removed price window calculation, passes currentTick directly
- processTickData: decimal adjustment (10^(d0-d1)), zero-edge trimming
- LiquidityChart: BarChart with hidden axes, p95 y-domain clamping, reference lines for assumedPrice / minPrice / maxPrice
- CustomLiquidityTooltip: decimal-adjusted price per bucket on hover
- formatTickPrice: precision formatter for token ratios (no $ prefix)
- PoolCharts: wires LiquidityChart with pool decimals and rangeInputs

## Fixes
- Split query fixes tick window exhaustion in dense pools (e.g. WETH/USDC) where 1000-tick limit was consumed before reaching currentTick
- Decimal adjustment (10^(d0-d1)) corrects raw tick math for cross-decimal pairs (e.g. USDC/WETH: 6 vs 18 decimals producing 500M instead of ~2000)
- p95 y-domain clamping prevents single outlier bars from collapsing the rest of the distribution visually
- Price scale inversion in nearest-bucket lookup aligns rangeInputs convention with processedData convention for correct reference line placement