### PR TITLE
feat(price-chart): increase data density, clean up axes

### DIFF
--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -184,6 +184,7 @@ export function PoolDetail() {
           <PoolCharts
             pool={pool}
             history={history}
+            hourlyData={hourlyData}
             selectedTokenIdx={selectedTokenIdx}
             tokenSymbols={tokenSymbols}
             rangeInputs={rangeInputs}

--- a/src/components/pool-detail/calculator/hooks/usePoolHourlyData.js
+++ b/src/components/pool-detail/calculator/hooks/usePoolHourlyData.js
@@ -1,16 +1,17 @@
 import { useState, useEffect } from 'react'
+import { formatHourlyData } from '../../../../loaders/utils/formatHourlyData'
 import { fetchPoolHourData } from '../../../../services/theGraphClient'
 
 /**
  * @typedef {Object} PoolHourDatas
- * @property {number} periodStartUnix - Timestamp of period start
- * @property {string} token0Price - Current token0 price
- * @property {string} token1Price - Current token1 price
- * @property {string} feesUSD - Accumulated fees from pool
- * @property {string} sqrtPrice - Square root of price (X96 format)
- * @property {string} liquidity - Total liquidity in pool
- * @property {string} tvlUSD - Total value locked
- * @property {string} tick - Current pool tick
+ * @property {number} periodStartUnix - Timestamp of period start (Unix seconds)
+ * @property {string} token0Price - Current token0 price (parsed float)
+ * @property {string} token1Price - Current token1 price (parsed float)
+ * @property {string} feesUSD - Accumulated fees is USD
+ * @property {string} liquidity - Total liquidity (precision loss acceptable)
+ * @property {string} tvlUSD - Total value locked in USD
+ * @property {string} dateShort - Tooltip label (e.g. "Feb 10 - 14:00")
+ * @property {string} dayLabel - Axis label: day number or month name at boundaries
  */
 
 /**
@@ -47,7 +48,8 @@ export function usePoolHourlyData(poolId, daysLookback = 7) {
       try {
         const startTime =
           Math.floor(Date.now() / 1000) - daysLookback * 24 * 60 * 60
-        const data = await fetchPoolHourData(poolId, startTime)
+        const rawData = await fetchPoolHourData(poolId, startTime)
+        const data = formatHourlyData(rawData)
 
         if (!cancelled) {
           setHourlyData(data)

--- a/src/components/pool-detail/charts/CustomPriceTooltip.jsx
+++ b/src/components/pool-detail/charts/CustomPriceTooltip.jsx
@@ -33,7 +33,8 @@ export function CustomPriceTooltip({
   payload,
   label,
   tokenSymbols,
-  selectedTokenIdx
+  selectedTokenIdx,
+  dateShortMap
 }) {
   if (!active || !payload?.length) return null
 
@@ -49,6 +50,8 @@ export function CustomPriceTooltip({
   // Precision: 8 decimals for micro-prices (<$1), 2 for readability (≥$1)
   const formattedPrice = price < 1 ? price.toFixed(8) : price.toFixed(2)
 
+  const displayLabel = dateShortMap?.get(label) ?? label
+
   return (
     <div
       className="rounded-lg p-3 shadow-lg border"
@@ -58,7 +61,7 @@ export function CustomPriceTooltip({
         color: CHART_COLORS.tooltip.text
       }}
     >
-      <p className="font-semibold mb-2">{label}</p>
+      <p className="font-semibold mb-2">{displayLabel}</p>
 
       <div className="flex items-center gap-2">
         <div

--- a/src/components/pool-detail/charts/PoolCharts.jsx
+++ b/src/components/pool-detail/charts/PoolCharts.jsx
@@ -18,6 +18,7 @@ import { FeesApyChart } from './FeesApyChart'
 export function PoolCharts({
   pool,
   history,
+  hourlyData,
   selectedTokenIdx,
   tokenSymbols,
   rangeInputs,
@@ -46,7 +47,7 @@ export function PoolCharts({
         currentPrice={currentPrice}
       />
       <PriceChart
-        history={history}
+        hourlyData={hourlyData}
         selectedTokenIdx={selectedTokenIdx}
         tokenSymbols={tokenSymbols}
         rangeInputs={rangeInputs}

--- a/src/components/pool-detail/charts/PriceChart.jsx
+++ b/src/components/pool-detail/charts/PriceChart.jsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import {
   LineChart,
   Line,
@@ -10,7 +11,6 @@ import {
 } from 'recharts'
 import { CustomPriceTooltip } from './CustomPriceTooltip'
 import { CHART_COLORS } from '../../../constants/chartColors'
-import { formatCompactCurrency } from '../../../utils/formatCompactCurrency'
 
 /**
  * UI: Strategic Price & Range Chart.
@@ -24,7 +24,7 @@ import { formatCompactCurrency } from '../../../utils/formatCompactCurrency'
  * @returns {JSX.Element}
  */
 export function PriceChart({
-  history,
+  hourlyData,
   selectedTokenIdx,
   tokenSymbols,
   rangeInputs,
@@ -32,6 +32,23 @@ export function PriceChart({
 }) {
   const dataKey = selectedTokenIdx === 0 ? 'token0Price' : 'token1Price'
   const selectedSymbol = tokenSymbols[selectedTokenIdx]
+
+  const dailyTicks = useMemo(() => {
+    if (!hourlyData?.length) return []
+    return hourlyData.filter((_, i) => i % 24 === 0)
+  }, [hourlyData])
+
+  const tickLabelMap = useMemo(() => {
+    if (!hourlyData?.length) return []
+    return new Map(dailyTicks.map((d) => [d.periodStartUnix, d.dayLabel]))
+  }, [hourlyData, dailyTicks])
+
+  const dateShortMap = useMemo(() => {
+    if (!hourlyData?.length) return []
+    return new Map(hourlyData.map((h) => [h.periodStartUnix, h.dateShort]))
+  }, [hourlyData])
+
+  if (!hourlyData?.length) return null
 
   return (
     <div className="card bg-base-200 rounded-2xl">
@@ -41,25 +58,24 @@ export function PriceChart({
         width="100%"
         height={window.innerWidth < 768 ? 200 : 300}
       >
-        <LineChart data={history}>
-          <CartesianGrid strokeDasharray="3 3" stroke={CHART_COLORS.grid} />
+        <LineChart data={hourlyData}>
 
           <XAxis
-            dataKey="dateShort"
-            stroke={CHART_COLORS.axis}
-            style={{ fontSize: '10px' }}
-            angle={-45}
+            dataKey="periodStartUnix"
+            axisLine={false}
+            ticks={dailyTicks.map((d) => d.periodStartUnix)}
+            tickFormatter={(v) => tickLabelMap.get(v) ?? ''}
+            tickLine={false}
+            style={{ fontSize: '12px' }}
             textAnchor="end"
             height={60}
           />
 
           <YAxis
+            hide
             stroke={CHART_COLORS.axis}
             style={{ fontSize: '11px' }}
             domain={[(dataMin) => dataMin * 0.9, (dataMax) => dataMax * 1.1]}
-            tickFormatter={(value) =>
-              value > 1 ? formatCompactCurrency(value) : value.toFixed(6)
-            }
           />
 
           <Line
@@ -105,6 +121,7 @@ export function PriceChart({
               <CustomPriceTooltip
                 tokenSymbols={tokenSymbols}
                 selectedTokenIdx={selectedTokenIdx}
+                dateShortMap={dateShortMap}
               />
             }
           />

--- a/src/loaders/utils/formatHourlyData.js
+++ b/src/loaders/utils/formatHourlyData.js
@@ -1,0 +1,33 @@
+/**
+ * Utility: Transforms raw PoolHourData from The Graph into chart-ready format.
+ *
+ * @param {Array} rawHourlyData - Array of poolHourData objects from API
+ * @returns {Array} Formatted hourly data with parsed numbers and readable dates
+ */
+export function formatHourlyData(rawHourlyData) {
+  if (!rawHourlyData || !rawHourlyData?.length) {
+    return []
+  }
+
+  return rawHourlyData.map((record) => {
+    const date = new Date(record.periodStartUnix * 1000)
+
+    const month = date.toLocaleString('en-US', { month: 'short' })
+    const day = date.getDate().toString().padStart(2, '0')
+    const hour = date.getHours().toString().padStart(2, '0')
+
+    // Month Boundary: show "Mar" instead of "01" when day rolls over
+    const dayLabel = date.getDate() === 1 ? month : day
+    const dateShort = `${month} ${day} - ${hour}:00`
+
+    return {
+      dateShort,
+      dayLabel,
+      token0Price: parseFloat(record.token0Price) || null,
+      token1Price: parseFloat(record.token1Price) || null,
+      periodStartUnix: parseInt(record.periodStartUnix),
+      tvlUSD: parseFloat(record.tvlUSD) || 0,
+      feesUSD: parseFloat(record.feesUSD) || 0
+    }
+  })
+}

--- a/src/loaders/utils/formatHourlyData.js
+++ b/src/loaders/utils/formatHourlyData.js
@@ -26,6 +26,7 @@ export function formatHourlyData(rawHourlyData) {
       token0Price: parseFloat(record.token0Price) || null,
       token1Price: parseFloat(record.token1Price) || null,
       periodStartUnix: parseInt(record.periodStartUnix),
+      liquidity: parseFloat(record.liquidity),
       tvlUSD: parseFloat(record.tvlUSD) || 0,
       feesUSD: parseFloat(record.feesUSD) || 0
     }


### PR DESCRIPTION
## What
Replaces 30-day daily price data with 7-day hourly data (168 points) in PriceChart, adds a data transformation pipeline for hourly snapshots, and cleans up axis visuals.

## Why
30 daily points provided insufficient resolution for range analysis.
Hourly granularity captures intraday volatility that matters for concentrated liquidity positioning decisions.
Axis cleanup reduces visual noise and aligns with the reference design.

## Changes
- `src/loaders/utils/formatHourlyData.js` (new) - transforms raw  TheGraph poolHourDatas: parses string prices to floats, formats Unix timestamps to dateShort ("Feb 10 - 14:00") and dayLabel (day number, month name at boundaries)
- `usePoolHourlyData.js` - pipes raw response through formatHourlyData before storing state; all consumers receive parsed data
- `PriceChart.jsx` - consumes hourlyData instead of history; XAxis subsampled to 1 label/day via ticks prop; YAxis hidden; unused formatCompactCurrency import removed
- `PoolCharts.jsx` - threads hourlyData prop down to PriceChart
- `PoolDetail.jsx` - passes hourlyData to PoolCharts

## Fixes
- Tooltip was showing raw Unix timestamp as label after XAxis dataKey change from dateShort to periodStartUnix - resolved via dateShortMap lookup passed to CustomPriceTooltip