### PR TITLE
chore(charts): cleanup deferred from feat/price-chart-polish

### DIFF
--- a/src/components/pool-detail/charts/PriceChart.jsx
+++ b/src/components/pool-detail/charts/PriceChart.jsx
@@ -68,7 +68,6 @@ export function PriceChart({
             tickLine={false}
             style={{ fontSize: '12px' }}
             textAnchor="end"
-            height={60}
           />
 
           <YAxis

--- a/src/loaders/utils/formatHourlyData.js
+++ b/src/loaders/utils/formatHourlyData.js
@@ -13,7 +13,7 @@ export function formatHourlyData(rawHourlyData) {
     const date = new Date(record.periodStartUnix * 1000)
 
     const month = date.toLocaleString('en-US', { month: 'short' })
-    const day = date.getDate().toString().padStart(2, '0')
+    const day = date.getDate().toString()
     const hour = date.getHours().toString().padStart(2, '0')
 
     // Month Boundary: show "Mar" instead of "01" when day rolls over


### PR DESCRIPTION
Deferred cleanup for feat/price-chart-polish:
- formatHourlyData: remove padStart(2, '0') from dayLabel for consistency with formatPoolHistory
- PriceChart XAxis: remove height={60} (was reserved for rotated labels, no longer needed after angle/-45 removal)