### PR TITLE
fix: use pool.token0Price as assumedPrice hydration source

### DIFF
--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -34,20 +34,19 @@ export function PoolDetail() {
     if (rangeInputs.minPrice !== '' || rangeInputs.maxPrice !== '') return
     if (!hourlyData) return
 
-    const currentPrice = parseFloat(hourlyData[0].token0Price)
-    const basePrice = selectedTokenIdx === 0 ? currentPrice : 1 / currentPrice
+    const currentPrice = selectedTokenIdx === 0 ? pool.token0Price || 0 : pool.token1Price || 0
 
     setRangeInputs((prev) => ({
       ...prev,
-      minPrice: basePrice * 0.9,
-      maxPrice: basePrice * 1.1,
-      assumedPrice: basePrice
+      minPrice: currentPrice * 0.9,
+      maxPrice: currentPrice * 1.1,
+      assumedPrice: currentPrice
     }))
 
     hasHydrated.current = true
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hourlyData, selectedTokenIdx])
+  }, [hourlyData, selectedTokenIdx, pool.token0Price, pool.token1Price])
   // Justification: rangeInputs.minPrice/maxPrice are guards, not triggers.
   // Including them would cause unnecessary effect re-runs on every input change.
 


### PR DESCRIPTION
## Problem
assumedPrice was hydrated from hourlyData[0].token0Price, a TheGraph snapshot that can lag behind actual market price.
This caused the calculator reference point (and charts reference lines) to initialize at a stale value, inconsistent with the current price shown in the UI.

## Fix
Use pool.token0Price / pool.token1Price (loader-sourced) as the hydration value. Same source trusted for LiquidityDristribution and PriceChart display.

## Notes
pool.token0Price arrives as Number - no parseFloat needed.