### PR TITLE
fix: correct price direction in liquidity distribution chart

### DIFF
--- a/src/components/pool-detail/charts/LiquidityChart.jsx
+++ b/src/components/pool-detail/charts/LiquidityChart.jsx
@@ -62,9 +62,8 @@ export function LiquidityChart({
     if (!processedData?.length) return {}
 
     const nearest = (target) => {
-      const scaledTarget = 1 / target
       return processedData.reduce((best, item) =>
-        Math.abs(item.price - scaledTarget) < Math.abs(best.price - scaledTarget)
+        Math.abs(item.price - target) < Math.abs(best.price - target)
         ? item
         : best
       ).price

--- a/src/components/pool-detail/charts/utils/processTickData.js
+++ b/src/components/pool-detail/charts/utils/processTickData.js
@@ -49,7 +49,7 @@ export function processTickData(
     const midTick = (Number(ticks[i].tickIdx) + Number(ticks[i + 1].tickIdx)) / 2
     const rawPrice = tickToPrice(midTick)
     const humanPrice = rawPrice * Math.pow(10, token0Decimals - token1Decimals)
-    const price = selectedTokenIdx === 0 ? humanPrice : 1 / humanPrice
+    const price = selectedTokenIdx === 0 ? 1 / humanPrice : humanPrice
     const liquidity = Math.max(0, liquidities[i])   // clamp float precision errors
 
     result.push({ price, liquidity })


### PR DESCRIPTION
## Problem
Liquidity distribution chart displayed prices in the wrong direction. humanPrice from tick conversion is token1/token0, but the UI convention (rangeInputs, priceLabel) expects token0/token1 when selectedTokenIdx === 0.

A 1/target workaround in referencePoints was compensating at the lookup layer instead of fixing the data.

## Fix
- `processTickData`: invert when idx=0, not idx=1
- `LiquidityChart`: remove the compensatory inversion from nearest() 

## Coupled changes
Both must ship together. Fixing processTickData alone double-inverts the reference lines.