### PR TITLE
fix(inferTokenPricesFromTVL): correct token price formula (div vs mul)

### DIFF
--- a/src/utils/inferTokenPricesFromTVL.js
+++ b/src/utils/inferTokenPricesFromTVL.js
@@ -66,9 +66,9 @@ export function inferTokenPricesFromTVL({
   }
 
   // Calculate prices using TVL proportions
-  const totalValueInToken1Units = tvlToken0 * currentPrice + tvlToken1
+  const totalValueInToken1Units = tvlToken0 / currentPrice + tvlToken1
   const priceToken1InUSD = tvlUSD / totalValueInToken1Units
-  const priceToken0InUSD = priceToken1InUSD * currentPrice
+  const priceToken0InUSD = priceToken1InUSD / currentPrice
 
   if (isInvalidPrice(priceToken0InUSD) || isInvalidPrice(priceToken1InUSD)) {
     return {


### PR DESCRIPTION
## Problem
`inferTokenPricesFromTVL` contained two arithmetic inversions that produced wrong USD prices for both tokens, causing astronomical fee projections in the Range Calculator.

**Bug 1** - wrong unit conversion:
tvlToken0 * currentPrice -> treats currentPrice as a multiplier but currentPrice = token0/token1, so converting token0 -> token1 requires division.

**Bug 2** - wrong price derivation:
priceToken0InUSD = priceToken1InUSD * currentPrice produces units ($/token1 * token0/token1) - dimensionally invalid.
Correct: priceToken1InUSD / currentPrice = $/token0.

## Why it was hidden
Both bugs partially cancelled each other out. When assumedPrice was sourced from `hourlyData[0].token0Price`, currentPrice in the simulation always fell within the user's range, keeping calculateLiquidity on the IN_RANGE branch where min(liq0, liq1) discarded the inflated broken amount.

After moving assumedPrice to `pool.token0Price` (a different snapshot), the price gap was enough to push currentPrice outside the hydrated range for several pools. The out-of-range branches in calculateLiquidity use a single token amount directly (no min() guard), so the inflated value propagated into L_user unconstrained, producing fee share values above 1000%.

## Fix
```js
// Before
const totalValueInToken1Units = tvlToken0 * currentPrice + tvlToken1
const priceToken0InUSD = priceToken1InUSD * currentPrice

// After
const totalValueInToken1Units = tvlToken0 / currentPrice + tvlToken1
const priceToken0InUSD = priceToken1InUSD / currentPrice
```

## Afected pools
Any pool where token0 has a small token0Price (e.g. WETH/USDT, WBTC/USDT) was at risk. Pools with large token0Price (e.g. USDC/WETH) showed low but plausible projections due to the cancellation effect.