### PR TITLE
fix(calculator): handle boundary price coincidence in liquidity calculation

### DIFF
--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -97,12 +97,12 @@ export function PoolDetail() {
         assumedPrice = currentPrice
       }
 
-      if (assumedPrice > maxPrice) {
+      if (assumedPrice >= maxPrice) {
         maxPrice = assumedPrice * 1.001
         minPrice = assumedPrice - width
       }
 
-      if (assumedPrice < minPrice) {
+      if (assumedPrice <= minPrice) {
         minPrice = assumedPrice * 0.999
         maxPrice = assumedPrice + width
       }

--- a/src/components/pool-detail/calculator/pipeline/validateInputs.js
+++ b/src/components/pool-detail/calculator/pipeline/validateInputs.js
@@ -62,10 +62,17 @@ export function validateInputs({
     }
 
     const assumedNum = Number(assumedPrice)
+
     if (!isFinite(assumedNum) || assumedNum <= 0) {
       return {
         success: false,
         error: 'Assumed Entry Price must be positive'
+      }
+    }
+    if (assumedNum < minNum || assumedNum > maxNum) {
+      return {
+        success: false,
+        error: 'Assumed Entry Price must be within the min/max price range.'
       }
     }
   }

--- a/src/components/pool-detail/calculator/utils/calculateLiquidity.js
+++ b/src/components/pool-detail/calculator/utils/calculateLiquidity.js
@@ -68,7 +68,12 @@ export function calculateLiquidity(
     const liq0 = (amount0 * (sqrtP * sqrtPHigh)) / (sqrtPHigh - sqrtP)
     const liq1 = amount1 / (sqrtP - sqrtPLow)
 
-    liquidity = Math.min(liq0, liq1)
+    if (liq0 !== 0 && liq1 !== 0) {
+      liquidity = Math.min(liq0, liq1)
+    } else {
+      liquidity = liq0 || liq1
+    }
+
     positionState = `IN_RANGE (binding: ${liq0 < liq1 ? 'token0' : 'token1'})`
 
     debugLog('In-Range Calculation:', {


### PR DESCRIPTION
## Problem
When `assumedPrice` landed exactly on a range boundary after tick alignment, `calculateTokenRatio` returned `amount0 = 0`. `calculateLiquidity` then computed `min(0, liq1) = 0`, triggering the "Invalid liquidity calculation" guard even for valid inputs.

The original epsilon fix (feat/contextual-price-hydration) addressed the hydration path but not the tick-alignment collapse inside the pipeline.

## Changes
- `PoolDetail`: tighten sliding guards to `>=` and `<=`
- `calculateLiquidity`: handle zero-amount single-sided in-range positions
- `validateInputs`: block `assumedPrice` genuinely outside `[minPrice, maxPrice]`

## Why these boundaries
Strict inequalities in `validateInputs` intentionally allow `assumedPrice === minPrice` and `assumedPrice === maxPrice`. The boundary coincidence cases now handled correctly by `calculateLiquidity`