### PR TITLE
Fix/pool detail responsive

### DIFF
--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -167,7 +167,7 @@ export function PoolDetail() {
   const avgAPY = calculateAverageAPY(last7Days, latestSnapshot.tvlUSD)
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-7xl">
+    <div className="container mx-auto px-4 pt-4 max-w-7xl">
       {/* NAVIGATION: Contextual return */}
       <Link to="/" className="btn btn-ghost btn-sm mb-6 gap-2">
         <span>←</span>

--- a/src/components/pool-detail/calculator/CalculatorInputs.jsx
+++ b/src/components/pool-detail/calculator/CalculatorInputs.jsx
@@ -217,7 +217,7 @@ export function CalculatorInputs({
               </span>
               <button className="btn btn-circle btn-xs">
                 <div
-                  className="tooltip tooltip-right"
+                  className="tooltip tooltip-bottom"
                   data-tip="It first populates with the most recent price for the pool. You can adjust your desired entry price for the range calculator."
                 >
                   <div className="font-medium text-base-content max-w-[120px] truncate">

--- a/src/components/pool-detail/charts/PriceChart.jsx
+++ b/src/components/pool-detail/charts/PriceChart.jsx
@@ -31,6 +31,10 @@ export function PriceChart({
 }) {
   const dataKey = selectedTokenIdx === 0 ? 'token0Price' : 'token1Price'
   const selectedSymbol = tokenSymbols[selectedTokenIdx]
+  const [baseToken, quoteToken] = tokenSymbols
+  const poolPriceLabel = selectedTokenIdx === 0
+    ? `${baseToken} / ${quoteToken}`
+    : `${quoteToken} / ${baseToken}`
 
   const dailyTicks = useMemo(() => {
     if (!hourlyData?.length) return []
@@ -62,7 +66,9 @@ export function PriceChart({
 
   return (
     <div className="card bg-base-200 rounded-2xl p-4">
-      <h3 className="text-lg font-semibold mb-4">Price - {selectedSymbol}</h3>
+      <h3 className="text-lg font-semibold mb-4">
+        {poolPriceLabel + ' Pool Price'}
+      </h3>
 
       <ResponsiveContainer
         width="100%"

--- a/src/components/pool-detail/charts/PriceChart.jsx
+++ b/src/components/pool-detail/charts/PriceChart.jsx
@@ -4,7 +4,6 @@ import {
   Line,
   XAxis,
   YAxis,
-  CartesianGrid,
   Tooltip,
   ResponsiveContainer,
   ReferenceLine
@@ -16,7 +15,7 @@ import { CHART_COLORS } from '../../../constants/chartColors'
  * UI: Strategic Price & Range Chart.
  * Visualizes asset price trends against liquidity provider boundaries.
  * @param {Object} props
- * @param {Array<Object>} props.history - Timeseries data from the pool API
+ * @param {Array<Object>} props.hourlyData - Timeseries data from the pool API
  * @param {number} props.selectedTokenIdx - Index of the token used as base price (0 or 1)
  * @param {string[]} props.tokenSymbols - Tuple of token symbols [Symbol0, Symbol1]
  * @param {Object} props.rangeInputs - Current simulation range (minPrice, maxPrice, assumedPrice)
@@ -48,6 +47,17 @@ export function PriceChart({
     return new Map(hourlyData.map((h) => [h.periodStartUnix, h.dateShort]))
   }, [hourlyData])
 
+  const yDomain = useMemo(() => {
+    if (!hourlyData?.length) return ['auto', 'auto']
+    const prices = hourlyData.map((h) => h[dataKey]).filter(Boolean)
+    const min = Math.min(...prices)
+    const max = Math.max(...prices)
+    const range = max - min
+
+    if (range === 0) return [min * 0.9, max * 1.15]
+    return [min - range * 0.15, max + range * 0.15]
+  }, [hourlyData, dataKey])
+
   if (!hourlyData?.length) return null
 
   return (
@@ -74,7 +84,7 @@ export function PriceChart({
             hide
             stroke={CHART_COLORS.axis}
             style={{ fontSize: '11px' }}
-            domain={[(dataMin) => dataMin * 0.9, (dataMax) => dataMax * 1.1]}
+            domain={yDomain}
           />
 
           <Line


### PR DESCRIPTION
## What
Mobile layout and chart quality fixes for the `PoolDetail` page.

## Why
Horizontal scroll in mobile was degrading the UX on the detail page.
`PriceChart` was rendering price variance in a compressed, hard-to-read way.

## Changes
- `tooltip-right` -> `tooltip-bottom` on Assumed Entry Price tooltip
- `PriceChart` Y-axis domain switched to variance-based padding
- `PriceChart` title now reflects selected token direction
- `PoolDetail` page wrapper: removed duplicate vertical padding

## Fixes
- ✔️ Horizontal scroll on mobile (340px+)
- ✔️ `PriceChart` flat-ish appearance on low-variance price periods