### PR TITLE
fix: improve hourly data coverage for LP range calculator

### DIFF
--- a/src/components/pool-detail/calculator/hooks/usePoolHourlyData.js
+++ b/src/components/pool-detail/calculator/hooks/usePoolHourlyData.js
@@ -18,7 +18,9 @@ import { fetchPoolHourData } from '../../../../services/theGraphClient'
  * Custom Hook: Fetch and cache TheGraph data.
  *
  * @param {string|number} poolId - Pool's unique identifier
- * @param {number} daysLookback - Amount of days to get data
+ * @param {number} daysLookback - Pipeline window in days (hook fetches daysLookback + 1
+ *                                days internally to guard against boundary drift and
+ *                                sparse gaps, then trims to daysLookback * 24 points)
  * @returns {{
  *    hourlyData: PoolHourDatas[],
  *    isLoading: boolean,
@@ -30,13 +32,17 @@ export function usePoolHourlyData(poolId, daysLookback = 7) {
   const [isLoading, setIsLoading] = useState(true)
   const [fetchError, setFetchError] = useState(null)
   /**
-   * Data Fetching: 7-Day Hourly Lookback.
-   * Retrieves 168 data points for fee growth simulation.
+   * Data Fetching: daysLookback Hourly Lookback.
+   * Fetches (daysLookback + 1) days of data points for fee growth simulation.
    *
-   * Why 7 days? Balance between:
+   * Why daysLookback + 1? Balance between:
    * - Sample size (statistical significance)
    * - Recency (captures current market conditions)
+   * - Allows for an extra buffer to exceed full hour boundaries (TheGraph)
    * Trade-off: Longer windows (30d) smooth outliers but miss regime changes.
+   *
+   * Note: The data get sliced to (daysLookback * 24) points to avoid
+   * inflated APR calculation.
    */
   useEffect(() => {
     setIsLoading(true)
@@ -46,13 +52,18 @@ export function usePoolHourlyData(poolId, daysLookback = 7) {
 
     async function loadHourlyData() {
       try {
+        // Extra buffer to circumvent full hour boundaries from TheGraph,
+        // and possible sparse gaps in the pool data due to low activity.
+        const fetchDays = daysLookback + 1
         const startTime =
-          Math.floor(Date.now() / 1000) - daysLookback * 24 * 60 * 60
+          Math.floor(Date.now() / 1000) - fetchDays * 24 * 60 * 60
         const rawData = await fetchPoolHourData(poolId, startTime)
         const data = formatHourlyData(rawData)
+        // slice the last 7 days to avoid inflated APR calculation
+        const result = data.slice(-(daysLookback * 24))
 
         if (!cancelled) {
-          setHourlyData(data)
+          setHourlyData(result)
           setIsLoading(false)
         }
       } catch (err) {

--- a/src/components/pool-detail/calculator/pipeline/validateInputs.js
+++ b/src/components/pool-detail/calculator/pipeline/validateInputs.js
@@ -77,8 +77,11 @@ export function validateInputs({
     }
   }
 
-  if (!hourlyData?.length || hourlyData.length < 168) {
-    return { success: false, error: 'No hourly data' }
+  if (!hourlyData?.length) {
+    return { success: false, error: 'No hourly data for this pool' }
+  }
+  if (hourlyData.length < 24) {
+    return { success: false, error: 'Insufficient hourly data (min. 24h required)'}
   }
 
   return { success: true }


### PR DESCRIPTION
## Problem
Too many pools were blocked by "No hourly data" in the range calculator, preventing the simulation pipeline from running.

Two root causes identified:

1. **Hour-boundary drift**: `startTime` was calculated at the current timestamp (e.g. 14:23:45), but TheGraph indexes `poolHourDatas` at full hour boundaries. The first matching entry was always the *next* full hour, reliably returning 167 points instead of 168, failing the hard `<168` check.
2. **Sparse pool gaps**: Low-activity pools have no `poolHourData` entry for quiet hours (no transactions = no entry). Any gap dropped the count below the threshold regardless of fetch window.

## Changes
**`usePoolHourlyData`** 
- Fetch window widened to `daysLookback + 1` days to absorb boundary drift and sparse gaps
- Results sliced to `daysLookback * 24` points before reaching the pipeline -> preserves the 7-day simulation and prevents APR inflation

**`validateInputs`**
- Hard block lowered from 168 -> 24 snapshots
- Pools with limited data now reach `assessDataQuality` and are handled by the INSUFFICIENT/LIMITED/RELIABLE/EXCELLENT quality tier system instead of being blocked entirely
- Split single condition into two with distinct error messages:
   `'No hourly data for this pool'` and `'Insufficient hourly data (min. 24h required)'`

## Out of scope
How error states are surfaced in `CalculatorStats` is tracked separately in `fix/calculator-error-ux`.