### PR TITLE
Feat/auth watchlist

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,13 @@
 import { RouterProvider } from 'react-router-dom'
 import { router } from './router'
+import { AuthProvider } from './context/AuthContext'
+import { AuthModal } from './components/common/AuthModal'
 
 export function App() {
-  return <RouterProvider router={router} />
+  return (
+    <AuthProvider>
+      <RouterProvider router={router} />
+      <AuthModal />
+    </AuthProvider>
+  )
 }

--- a/src/components/common/AuthModal.jsx
+++ b/src/components/common/AuthModal.jsx
@@ -1,10 +1,28 @@
 import { useState } from 'react'
 import {
   signInWithEmailAndPassword,
-  createUserWithEmailAndPassword
+  createUserWithEmailAndPassword,
+  GoogleAuthProvider,
+  signInWithPopup
 } from 'firebase/auth'
 import { auth } from '../../../firebase'
 import { useAuth } from '../../context/AuthContext'
+
+const mapFirebaseError = (code) => {
+  const errorMap = {
+    'auth/user-not-found': 'No account found with this email',
+    'auth/wrong-password': 'Incorrect password',
+    'auth/email-already-in-use': 'An account with this email already exists',
+    'auth/weak-password': 'Password must be at least 6 characters',
+    'auth/invalid-email': 'Invalid email address',
+    'auth/invalid-credential': 'Email or password incorrect',
+    'auth/popup-closed-by-user': 'Sign-in cancelled'
+  }
+
+  return errorMap[code] || "Something went wrong. Please try again"
+}
+
+const googleProvider = new GoogleAuthProvider()
 
 export function AuthModal() {
   const [isLoginMode, setIsLoginMode] = useState(true)
@@ -42,17 +60,18 @@ export function AuthModal() {
     }
   }
 
-  const mapFirebaseError = (code) => {
-    const errorMap = {
-      'auth/user-not-found': 'No account found with this email',
-      'auth/wrong-password': 'Incorrect password',
-      'auth/email-already-in-use': 'An account with this email already exists',
-      'auth/weak-password': 'Password must be at least 6 characters',
-      'auth/invalid-email': 'Invalid email address',
-      'auth/invalid-credential': 'Email or password incorrect',
-    }
+  const handleGoogleSignIn = async () => {
+    setError(null)
+    setIsLoading(true)
 
-    return errorMap[code] || "Something went wrong. Please try again"
+    try {
+      await signInWithPopup(auth, googleProvider)
+      handleClose()
+    } catch (err) {
+      setError(mapFirebaseError(err.code))
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   return (
@@ -65,32 +84,40 @@ export function AuthModal() {
           ✕
         </button>
 
-        <h3 className="text-2xl font-bold">
-          {isLoginMode ? 'Sign In' : 'Create Account'}
+        <h3 className="text-2xl font-bold text-center p-4">
+          {isLoginMode ? 'Welcome' : 'Create Account'}
         </h3>
 
         <form onSubmit={handleSubmit}>
-          <label className="label">
+          <label
+            htmlFor="email"
+            className="label flex flex-col items-start mb-2"
+          >
             <span className="label-text mt-2">Email address</span>
-            <input
-              type="email"
-              className="input input-bordered w-full mt-1"
-              aria-label="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-            />
           </label>
+          <input
+            id="email"
+            type="email"
+            className="input input-bordered w-full mt-1"
+            aria-label="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
 
-          <label className="label">
+          <label
+            htmlFor="password"
+            className="label flex flex-col items-start mb-2"
+          >
             <span className="label-text mt-2">Password</span>
-            <input
-              type="password"
-              className="input input-bordered w-full mt-1"
-              aria-label="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
           </label>
+          <input
+            id="password"
+            type="password"
+            className="input input-bordered w-full mt-1"
+            aria-label="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
 
           {error && (
             <div className="alert alert-error text-sm font-semibold mt-4">
@@ -98,14 +125,30 @@ export function AuthModal() {
             </div>
           )}
 
-          <button type="submit" className="btn btn-primary w-full" disabled={isLoading}>
+          <button type="submit" className="btn btn-primary w-full mt-4" disabled={isLoading}>
             {isLoading && <span className="loading loading-spinner loading-sm" />}
-            {isLoginMode ? 'Sign In' : 'Create Account'}
+            {isLoginMode ? 'Log In' : 'Create Account'}
           </button>
         </form>
 
+        <div className="divider text-base-content my-8">OR</div>
+
         <button
-          className="btn btn-ghost text-sm text-base-content/60"
+          className="btn btn-outline w-full mb-2"
+          onClick={handleGoogleSignIn}
+          disabled={isLoading}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" className="w-5 h-5 mr-2">
+            <path fill="#FFC107" d="M43.611,20.083H42V20H24v8h11.303c-1.649,4.657-6.08,8-11.303,8c-6.627,0-12-5.373-12-12c0-6.627,5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24s8.955,20,20,20s20-8.955,20-20C44,22.659,43.862,21.35,43.611,20.083z"/>
+            <path fill="#FF3D00" d="M6.306,14.691l6.571,4.819C14.655,15.108,18.961,12,24,12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z"/>
+            <path fill="#4CAF50" d="M24,44c5.166,0,9.86-1.977,13.409-5.192l-6.19-5.238C29.211,35.091,26.715,36,24,36c-5.202,0-9.619-3.317-11.283-7.946l-6.522,5.025C9.505,39.556,16.227,44,24,44z"/>
+            <path fill="#1976D2" d="M43.611,20.083H42V20H24v8h11.303c-0.792,2.237-2.231,4.166-4.087,5.571l6.19,5.238C40.483,35.58,44,30.222,44,24C44,22.659,43.862,21.35,43.611,20.083z"/>
+          </svg>
+          Continue with Google
+        </button>
+
+        <button
+          className="btn btn-ghost text-sm text-base-content/60 mt-4 block mx-auto"
           onClick={() => {
             setIsLoginMode(prev => !prev)
             setError(null)
@@ -113,7 +156,7 @@ export function AuthModal() {
         >
           {isLoginMode
             ? 'Don\'t have an account? Sign up ↗'
-            : 'Already have an account? Sign in ↗'}
+            : 'Already have an account? Log in ↗'}
         </button>
 
       </div>

--- a/src/components/common/AuthModal.jsx
+++ b/src/components/common/AuthModal.jsx
@@ -1,0 +1,125 @@
+import { useState } from 'react'
+import {
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword
+} from 'firebase/auth'
+import { auth } from '../../../firebase'
+import { useAuth } from '../../context/AuthContext'
+
+export function AuthModal() {
+  const [isLoginMode, setIsLoginMode] = useState(true)
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const { closeAuthModal, isAuthModalOpen } = useAuth()
+
+  const handleClose = () => {
+    setEmail('')
+    setPassword('')
+    setError(null)
+    setIsLoginMode(true)
+    closeAuthModal()
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError(null)
+    setIsLoading(true)
+
+    try {
+      if (isLoginMode) {
+        await signInWithEmailAndPassword(auth, email, password)
+      } else {
+        await createUserWithEmailAndPassword(auth, email, password)
+      }
+      handleClose()
+    } catch (err) {
+        setError(mapFirebaseError(err.code))
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const mapFirebaseError = (code) => {
+    const errorMap = {
+      'auth/user-not-found': 'No account found with this email',
+      'auth/wrong-password': 'Incorrect password',
+      'auth/email-already-in-use': 'An account with this email already exists',
+      'auth/weak-password': 'Password must be at least 6 characters',
+      'auth/invalid-email': 'Invalid email address',
+      'auth/invalid-credential': 'Email or password incorrect',
+    }
+
+    return errorMap[code] || "Something went wrong. Please try again"
+  }
+
+  return (
+    <dialog className={`modal ${isAuthModalOpen ? 'modal-open' : ''}`}>
+      <div className="modal-box max-w-xl bg-base-200">
+        <button
+          className="btn btn-ghost btn-sm btn-circle absolute right-2 top-2"
+          onClick={handleClose}
+        >
+          ✕
+        </button>
+
+        <h3 className="text-2xl font-bold">
+          {isLoginMode ? 'Sign In' : 'Create Account'}
+        </h3>
+
+        <form onSubmit={handleSubmit}>
+          <label className="label">
+            <span className="label-text mt-2">Email address</span>
+            <input
+              type="email"
+              className="input input-bordered w-full mt-1"
+              aria-label="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </label>
+
+          <label className="label">
+            <span className="label-text mt-2">Password</span>
+            <input
+              type="password"
+              className="input input-bordered w-full mt-1"
+              aria-label="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </label>
+
+          {error && (
+            <div className="alert alert-error text-sm font-semibold mt-4">
+              {error}
+            </div>
+          )}
+
+          <button type="submit" className="btn btn-primary w-full" disabled={isLoading}>
+            {isLoading && <span className="loading loading-spinner loading-sm" />}
+            {isLoginMode ? 'Sign In' : 'Create Account'}
+          </button>
+        </form>
+
+        <button
+          className="btn btn-ghost text-sm text-base-content/60"
+          onClick={() => {
+            setIsLoginMode(prev => !prev)
+            setError(null)
+          }}
+        >
+          {isLoginMode
+            ? 'Don\'t have an account? Sign up ↗'
+            : 'Already have an account? Sign in ↗'}
+        </button>
+
+      </div>
+      <form method="dialog" className="modal-backdrop">
+        <button onClick={handleClose}>close</button>
+      </form>
+    </dialog>
+  )
+}

--- a/src/components/common/StarIcons.jsx
+++ b/src/components/common/StarIcons.jsx
@@ -1,0 +1,13 @@
+export const OutlinedStarIcon = () => (
+  <svg className="w-5 h-5 text-base-content" fill="none" viewBox="0 0 24 24"
+    strokeWidth={1.5} stroke="currentColor" xmlns="http://www.w3.org/2000/svg" >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
+  </svg>
+)
+
+export const FilledStarIcon = () => (
+  <svg className="w-5 h-5 text-warning" fill="currentColor" viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg">
+    <path fillRule="evenodd" d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.006 5.404.434c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.434 2.082-5.005Z" clipRule="evenodd" />
+  </svg>
+)

--- a/src/components/layout/FavoritesLayout.jsx
+++ b/src/components/layout/FavoritesLayout.jsx
@@ -1,0 +1,10 @@
+import { Outlet } from 'react-router-dom'
+import { useFavorites } from '../../hooks/useFavorites'
+
+export function FavoritesLayout() {
+  const { favoriteIds, toggleFavorite, isLoggedIn } = useFavorites()
+
+  return (
+    <Outlet context={{ favoriteIds, toggleFavorite, isLoggedIn }} />
+  )
+}

--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -1,4 +1,4 @@
-import { useLoaderData, Link } from 'react-router-dom'
+import { useLoaderData, Link, useOutletContext } from 'react-router-dom'
 import { useCallback, useEffect, useState, useRef } from 'react'
 import { ContractLinks } from './ContractLinks'
 import { CurrentPriceCard } from './CurrentPriceCard'
@@ -9,6 +9,7 @@ import { usePoolTickData } from './charts/hooks/usePoolTickData'
 import { processTickData } from './charts/utils/processTickData'
 import { invertPriceRange } from './calculator/utils/invertPriceRange'
 import { inferRangeFromLiquidity } from './calculator/utils/inferRangeFromLiquidity'
+import { OutlinedStarIcon, FilledStarIcon } from '../common/StarIcons'
 
 const DexScreenLogo = () => (
   <svg width="1.5em" height="1.5em" viewBox="0 0 252 300"
@@ -40,6 +41,7 @@ export function PoolDetail() {
     tickData,
     fetchError: tickError
   } = usePoolTickData(pool.id, pool.tick, pool.feeTier)
+  const { favoriteIds, toggleFavorite } = useOutletContext()
   const hasHydrated = useRef(false)
   const [selectedTokenIdx, setSelectedTokenIdx] = useState(0)
   const [rangeInputs, setRangeInputs] = useState({
@@ -174,6 +176,9 @@ export function PoolDetail() {
   const last7Days = history.slice(-7)
   const avgAPY = calculateAverageAPY(last7Days, latestSnapshot.tvlUSD)
 
+  // Check if pool is in the user's watchlist
+  const isFavorited = favoriteIds.has(pool.id)
+
   return (
     <div className="container mx-auto px-4 pt-4 max-w-7xl">
       {/* NAVIGATION: Contextual return */}
@@ -222,7 +227,7 @@ export function PoolDetail() {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <button className="btn btn-ghost btn-sm">
+                  <button className="btn btn-ghost btn-circle btn-sm">
                     <DexScreenLogo />
                   </button>
                 </a>
@@ -234,10 +239,22 @@ export function PoolDetail() {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <button className="btn btn-ghost btn-sm">
+                  <button className="btn btn-ghost btn-circle btn-sm">
                     <BlockExplorerIcon />
                   </button>
                 </a>
+              </div>
+
+              <div
+                className="tooltip"
+                data-tip={`${isFavorited ? 'Remove from' : 'Add to'} Watchlist`}
+              >
+                <button
+                  className="btn btn-ghost btn-circle btn-sm"
+                  onClick={() => toggleFavorite(pool.id)}
+                >
+                  {isFavorited ? <FilledStarIcon /> : <OutlinedStarIcon />}
+                </button>
               </div>
             </div>
           </div>

--- a/src/components/pools/PoolTable.jsx
+++ b/src/components/pools/PoolTable.jsx
@@ -12,6 +12,20 @@ import { PlatformIcon } from '../common/PlatformIcon'
 import { useBreakpoint } from '../../hooks/useBreakpoint'
 import { useIntersection } from '../../hooks/useIntersection'
 
+const OutlinedStarIcon = () => (
+  <svg className="w-4 h-4 text-base-content/60" fill="none" viewBox="0 0 24 24"
+    strokeWidth={1.5} stroke="currentColor" xmlns="http://www.w3.org/2000/svg" >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
+  </svg>
+)
+
+const FilledStarIcon = () => (
+  <svg className="w-4 h-4 text-warning" fill="currentColor" viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg">
+    <path fillRule="evenodd" d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.006 5.404.434c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.434 2.082-5.005Z" clipRule="evenodd" />
+  </svg>
+)
+
 /**
  * Z-INDEX HIERARCHY (Critical for sticky positioning):
  * z-2: Body cells (sticky first column on horizontal scroll)
@@ -40,11 +54,21 @@ import { useIntersection } from '../../hooks/useIntersection'
  * @param {Array<id: string, desc: boolean>} props.sorting - TanStack sorting state
  * @param {Function} props.onSortingChange - Handler to update sorting criteria
  * @param {React.ForwardedRef<HTMLDivElement[lang="en"]>} ref - Ref to internal scroll container (for auto-scroll)
+ * @param {Set<string>} props.favoriteIds - Favorited pool IDs; used for O(1) isFavorited lookup
+ * @param {(poolId: string) => Promise<void>} props.toggleFavorite - Toggles favorite; opens auth modal if unauthenticated
  * @returns {JSX.Element}
  */
 const PoolTable = forwardRef(
   (
-    { pools, sparklineData, onVisiblePoolsChange, sorting, onSortingChange },
+    {
+      pools,
+      sparklineData,
+      onVisiblePoolsChange,
+      sorting,
+      onSortingChange,
+      favoriteIds,
+      toggleFavorite
+    },
     ref
   ) => {
     const { isDesktop } = useBreakpoint()
@@ -70,30 +94,42 @@ const PoolTable = forwardRef(
         if (col.accessorKey === 'name') {
           return {
             ...col,
-            cell: ({ row }) => (
-              <Link
-                to={`/pools/${row.original.id}`}
-                className="block"
-                aria-label={`View details for ${row.original.name} pool`}
-              >
+            cell: ({ row }) => {
+              const isFavorited = favoriteIds.has(row.original.id)
+
+              return (
                 <div className="flex items-center gap-2">
-
-                  <div
-                    className="tooltip tooltip-right"
-                    data-tip={row.original.name}
+                  <button
+                    className="btn btn-ghost btn-circle btn-sm"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      toggleFavorite(row.original.id)
+                    }}
                   >
-                    <div className="font-medium text-base-content max-w-[120px] truncate">
-                      {row.original.name}
+                    {isFavorited ? <FilledStarIcon /> : <OutlinedStarIcon />}
+                  </button>
+
+                  <Link
+                    to={`/pools/${row.original.id}`}
+                    className="flex items-center gap-2"
+                    aria-label={`View details for ${row.original.name} pool`}
+                  >
+                    <div
+                      className="tooltip tooltip-right"
+                      data-tip={row.original.name}
+                    >
+                      <div className="font-medium text-base-content max-w-[120px] truncate">
+                        {row.original.name}
+                      </div>
                     </div>
-                  </div>
 
-                  <span className="badge badge-sm text-base-content/50 border border-base-content/20">
-                    {row.original.feeTierFormatted}
-                  </span>
-
+                    <span className="badge badge-sm text-base-content/50 border border-base-content/20">
+                      {row.original.feeTierFormatted}
+                    </span>
+                  </Link>
                 </div>
-              </Link>
-            )
+              )
+            }
           }
         }
 

--- a/src/components/pools/PoolTable.jsx
+++ b/src/components/pools/PoolTable.jsx
@@ -9,22 +9,9 @@ import {
 import { baseColumns } from '../../data/tableColumns'
 import { SparklineCell } from './cells/SparklineCell'
 import { PlatformIcon } from '../common/PlatformIcon'
+import { OutlinedStarIcon, FilledStarIcon } from '../common/StarIcons'
 import { useBreakpoint } from '../../hooks/useBreakpoint'
 import { useIntersection } from '../../hooks/useIntersection'
-
-const OutlinedStarIcon = () => (
-  <svg className="w-4 h-4 text-base-content/60" fill="none" viewBox="0 0 24 24"
-    strokeWidth={1.5} stroke="currentColor" xmlns="http://www.w3.org/2000/svg" >
-    <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
-  </svg>
-)
-
-const FilledStarIcon = () => (
-  <svg className="w-4 h-4 text-warning" fill="currentColor" viewBox="0 0 24 24"
-    xmlns="http://www.w3.org/2000/svg">
-    <path fillRule="evenodd" d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.006 5.404.434c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.434 2.082-5.005Z" clipRule="evenodd" />
-  </svg>
-)
 
 /**
  * Z-INDEX HIERARCHY (Critical for sticky positioning):
@@ -99,15 +86,20 @@ const PoolTable = forwardRef(
 
               return (
                 <div className="flex items-center gap-2">
-                  <button
-                    className="btn btn-ghost btn-circle btn-sm"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      toggleFavorite(row.original.id)
-                    }}
+                  <div
+                    className="tooltip tooltip-right"
+                    data-tip={`${isFavorited ? 'Remove from' : 'Add to'} Watchlist`}
                   >
-                    {isFavorited ? <FilledStarIcon /> : <OutlinedStarIcon />}
-                  </button>
+                    <button
+                      className="btn btn-ghost btn-circle btn-sm"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        toggleFavorite(row.original.id)
+                      }}
+                    >
+                      {isFavorited ? <FilledStarIcon /> : <OutlinedStarIcon />}
+                    </button>
+                  </div>
 
                   <Link
                     to={`/pools/${row.original.id}`}
@@ -214,7 +206,7 @@ const PoolTable = forwardRef(
 
         return col
       })
-    }, [sparklineData])
+    }, [sparklineData, favoriteIds, toggleFavorite])
 
     const visibleColumns = useMemo(() => {
       return columns.filter((col) => {

--- a/src/components/pools/PoolsContent.jsx
+++ b/src/components/pools/PoolsContent.jsx
@@ -27,7 +27,9 @@ export function PoolsContent({
   filters,
   updateFilter,
   togglePlatform,
-  clearFilters
+  clearFilters,
+  favoriteIds,
+  toggleFavorite
 }) {
   // Platform dropdown options (sorted alphabetically)
   const availablePlatforms = useMemo(() => {
@@ -192,6 +194,8 @@ export function PoolsContent({
             currentPage={pageIndex + 1}
             sorting={sorting}
             onSortingChange={handleSortingChange}
+            favoriteIds={favoriteIds}
+            toggleFavorite={toggleFavorite}
           />
           <div className="py-4">
             <PaginationControls

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -37,7 +37,7 @@ export const AuthProvider = ({ children }) => {
 export const useAuth = () => {
   const context = useContext(AuthContext)
   if (!context) {
-    throw new Error('useAuth must be used within an AuthProvider')
+    throw new Error("useAuth must be used within an AuthProvider")
   }
   return context
 }

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useState, useEffect } from 'react'
+import { onAuthStateChanged } from 'firebase/auth'
+import { auth } from '../../firebase'
+
+const AuthContext = createContext(null)
+
+export const AuthProvider = ({ children }) => {
+  const [currentUser, setCurrentUser] = useState(null)
+  const [isAuthModalOpen, setIsAuthModalOpen] = useState(false)
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setCurrentUser(user ?? false)
+    })
+
+    return () => unsubscribe()
+  }, [])
+
+  const openAuthModal = () => setIsAuthModalOpen(true)
+  const closeAuthModal = () => setIsAuthModalOpen(false)
+
+  return (
+    <AuthContext.Provider
+      value={{
+        currentUser,
+        openAuthModal,
+        closeAuthModal,
+        isAuthModalOpen
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useAuth = () => {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/src/hooks/useFavorites.js
+++ b/src/hooks/useFavorites.js
@@ -1,0 +1,87 @@
+import { useState, useEffect } from 'react'
+import { useAuth } from '../context/AuthContext'
+import { db } from '../../firebase'
+import {
+  collection,
+  doc,
+  getDocs,
+  setDoc,
+  deleteDoc,
+  serverTimestamp
+} from 'firebase/firestore'
+
+/**
+ * Custom Hook: Fetch watchlist favorites from a user's collection (Firebase)
+ *
+ * @returns {{
+ *  favoriteIds: Set<string>,
+ *  toggleFavorite: (poolId: string) => Promise<void>,
+ *  isLoggedIn: boolean
+ * }}
+ */
+export function useFavorites() {
+  const { currentUser, openAuthModal } = useAuth()
+  const [favoriteIds, setFavoriteIds] = useState(new Set())
+
+  /**
+   * Data Fetching: User-saved pools from Firebase.
+   *
+   * Fetches poolIds from the user's collection to be consumed by
+   * PoolTable, PoolDetail, and Watchlist page.
+   */
+  useEffect(() => {
+    if (currentUser === null) return
+    if (!currentUser) {
+      setFavoriteIds(new Set())
+      return
+    }
+    let cancelled = false
+
+    const fetchFavorites = async () => {
+      const favoritesRef = collection(db, "users", currentUser.uid, "favorites")
+      const querySnapshot = await getDocs(favoritesRef)
+      const poolIds = new Set(querySnapshot.docs.map((doc) => doc.id))
+
+      if (!cancelled) {
+        setFavoriteIds(poolIds)
+      }
+    }
+
+    fetchFavorites()
+    // Cleanup: Prevents state update on unmounted component
+    return () => { cancelled = true }
+  }, [currentUser])
+
+  /**
+   * Toggles a pool's favorite status in Firestore and updates local Set optimistically.
+   * Opens the auth modal if the user is not authenticated.
+   *
+   * Note: Optimistic update - local Set changes before Firestore confirms.
+   * If the Firestore write fails, Set might be out of sync until next fetch.
+   *
+   * @param {string} poolId - Pool contract address, used as the Firestore document ID
+   * @returns {Promise<void>}
+   */
+  const toggleFavorite = async (poolId) => {
+    if (!currentUser) {
+      openAuthModal()
+      return
+    }
+    const docRef = doc(db, "users", currentUser.uid, "favorites", poolId)
+
+    if (favoriteIds.has(poolId)) {
+      setFavoriteIds((prev) => {
+        const next = new Set(prev)
+        next.delete(poolId)
+        return next
+      })
+      await deleteDoc(docRef)
+
+    } else {
+      setFavoriteIds((prev) => new Set([...prev, poolId]))
+      await setDoc(docRef, { poolId, addedAt: serverTimestamp() })
+    }
+  }
+
+  return { favoriteIds, toggleFavorite, isLoggedIn: !!currentUser }
+}

--- a/src/loaders/watchlistLoader.js
+++ b/src/loaders/watchlistLoader.js
@@ -1,3 +1,37 @@
+import { redirect } from 'react-router-dom'
+import { auth, db } from '../../firebase'
+import { collection, getDocs } from 'firebase/firestore'
+import { fetchWatchedPools } from '../services/theGraphClient'
+import { formatPoolData } from './utils/formatPoolData'
+
+/**
+ * Loader: Watchlist Page
+ *
+ * Two-phase fetch:
+ *   1. Firestore  -> user's favorited pool IDs
+ *   2. TheGraph   -> live pool data for those IDs (same shape as poolsLoader)
+ *
+ * Hard redirects to '/' if unauthenticated.
+ * Short-circuits before TheGraph call if watchlist is empty.
+ *
+ * Note: auth.currentUser is synchronous and may be null on hard refresh
+ * before Firebase resolves. Acceptable trade-off for portfolio scope.
+ *
+ * @returns {Promise<{ pools: Array<Object> } | Response>}
+ */
 export async function watchlistLoader() {
-  return { favorites: [] }
+  // Hard redirect if unauthenticated
+  if (auth.currentUser === null) return redirect('/')
+
+  // Phase 1: Firestore -> pool IDs
+  const snapshot = await getDocs(
+    collection(db, 'users', auth.currentUser.uid, 'favorites')
+  )
+  const poolIds = snapshot.docs.map((doc) => doc.id)
+  if (!poolIds.length) return { pools: [] }
+
+  // Phase 2: TheGraph -> live pool data
+  const raw = await fetchWatchedPools(poolIds)
+
+  return { pools: formatPoolData(raw) }
 }

--- a/src/pages/Pools.jsx
+++ b/src/pages/Pools.jsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from 'react-router-dom'
+import { useLoaderData, useOutletContext } from 'react-router-dom'
 import { useMediaQuery } from 'react-responsive'
 import { usePoolFilters } from '../hooks/usePoolFIlters'
 import { PoolsContent } from '../components/pools/PoolsContent'
@@ -13,8 +13,8 @@ export default function Pools() {
   const { pools } = useLoaderData()
   const isDesktop = useMediaQuery({ minWidth: 769 })
 
-  const { filters, updateFilter, togglePlatform, clearFilters } =
-    usePoolFilters()
+  const { filters, updateFilter, togglePlatform, clearFilters } = usePoolFilters()
+  const { favoriteIds, toggleFavorite } = useOutletContext()
 
   return (
     <div className="mx-auto max-w-7xl">
@@ -31,6 +31,8 @@ export default function Pools() {
         togglePlatform={togglePlatform}
         clearFilters={clearFilters}
         isDesktop={isDesktop}
+        favoriteIds={favoriteIds}
+        toggleFavorite={toggleFavorite}
       />
     </div>
   )

--- a/src/pages/Watchlist.jsx
+++ b/src/pages/Watchlist.jsx
@@ -1,5 +1,71 @@
-import React from 'react'
+import { useLoaderData, useOutletContext } from 'react-router-dom'
+import { useRef, useState, useMemo } from 'react'
+import { PoolTable } from '../components/pools/PoolTable'
+import { PaginationControls } from '../components/common/PaginationControls'
+import { useSparklines } from '../hooks/useSparklines'
+
+const PAGE_SIZE = 40
 
 export default function Watchlist() {
-  return <h1 className="mb-6">Watchlist Component goes here</h1>
+  const { pools } = useLoaderData()
+  const { favoriteIds, toggleFavorite } = useOutletContext()
+  const [sorting, setSorting] = useState([])
+  const [currentPage, setCurrentPage] = useState(1)
+  const [visiblePoolIds, setVisiblePoolIds] = useState(new Set())
+  const tableRef = useRef(null)
+  const tableScrollRef = useRef(null)
+
+  const totalPages = Math.ceil(pools.length / PAGE_SIZE)
+  const paginatedPools = pools.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE
+  )
+
+  const visiblePools = useMemo(() => {
+    return new Set(
+      pools.filter((p) => visiblePoolIds.has(p.id))
+    )
+  }, [pools, visiblePoolIds])
+
+  const { sparklineData } = useSparklines({
+    visiblePools,
+    currentPage: 1  // No freemium gate on watchlist
+  })
+
+  if (!pools.length) {
+    return (
+      <div className="flex flex-col items-center justify-center py-32 text-base-content/50">
+        <p className="text-lg font-medium">No saved pools yet.</p>
+        <p className="text-sm mt-1">Star a pool from the main table to add it here.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold text-base-content mb-6">My Watchlist</h1>
+      <div
+        ref={tableRef}
+        className="bg-base-200 -mx-4 sm:-mx-6 md:-mx-4 rounded-3xl shadow-lg"
+      >
+        <PoolTable
+          ref={tableScrollRef}
+          pools={paginatedPools}
+          sparklineData={sparklineData}
+          favoriteIds={favoriteIds}
+          toggleFavorite={toggleFavorite}
+          sorting={sorting}
+          onSortingChange={setSorting}
+          onVisiblePoolsChange={setVisiblePoolIds}
+        />
+          <div className="py-4">
+            <PaginationControls
+              totalPages={totalPages}
+              currentPage={currentPage}
+              onPageChange={setCurrentPage}
+            />
+          </div>
+      </div>
+    </div>
+  )
 }

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -6,6 +6,7 @@ import {
 import Pools from './pages/Pools'
 import Watchlist from './pages/Watchlist'
 import { Layout } from './components/layout/Layout'
+import { FavoritesLayout } from './components/layout/FavoritesLayout'
 import { PoolDetail } from './components/pool-detail/PoolDetail'
 import { Error } from './components/common/Error'
 import { poolsLoader } from './loaders/poolsLoader'
@@ -32,18 +33,20 @@ import { watchlistLoader } from './loaders/watchlistLoader'
 export const router = createBrowserRouter(
   createRoutesFromElements(
     <Route path="/" element={<Layout />}>
-      <Route
-        path="pools/:poolId"
-        element={<PoolDetail />}
-        loader={poolDetailLoader}
-        errorElement={<Error />}
-      />
-      <Route index element={<Pools />} loader={poolsLoader} />
-      <Route
-        path="watchlist"
-        element={<Watchlist />}
-        loader={watchlistLoader}
-      />
+      <Route element={<FavoritesLayout />}>
+        <Route
+          path="pools/:poolId"
+          element={<PoolDetail />}
+          loader={poolDetailLoader}
+          errorElement={<Error />}
+        />
+        <Route index element={<Pools />} loader={poolsLoader} />
+        <Route
+          path="watchlist"
+          element={<Watchlist />}
+          loader={watchlistLoader}
+        />
+      </Route>
     </Route>
   )
 )

--- a/src/services/theGraphClient.js
+++ b/src/services/theGraphClient.js
@@ -222,6 +222,68 @@ const GET_POOL_SPARKLINES_QUERY = gql`
 `
 
 /**
+ * Query: Fetches a specific set of pools by ID from TheGraph.
+ * Used by the watchlist loader to retrieve fresh data for user-saved pools.
+ *
+ * Variable: $ids [ID!] - Array of pool contract addresses
+ * Ordered by TVL descending (highest liquidity pools surface first)
+ */
+const GET_WATCHED_POOLS_QUERY = gql`
+  query GetWatchedPools($ids: [ID!]) {
+    pools(
+      where: { id_in: $ids }
+      orderBy: totalValueLockedUSD
+      orderDirection: desc
+    ) {
+      id
+      feeTier
+      liquidity
+      totalValueLockedUSD
+      totalValueLockedToken0
+      totalValueLockedToken1
+      volumeUSD
+      volumeToken0
+      volumeToken1
+      collectedFeesUSD
+      collectedFeesToken0
+      collectedFeesToken1
+      token0Price
+      token1Price
+      createdAtTimestamp
+      token0 {
+        id
+        symbol
+        name
+      }
+      token1 {
+        id
+        symbol
+        name
+      }
+    }
+  }
+`
+
+/**
+ * Service: Batch-fetches live pool data for a user's watchlist.
+ * Returns the same shape as fetchPools() - compatible with PoolTable rendering.
+ *
+ * @param {string[]} poolIds - Pool contract addresses from Firestore favorites
+ * @returns {Promise<Array>} Fresh pool objects ordered by TVL desc
+ *
+ * @example
+ * const pools = await fetchWatchedPools([
+ *  "0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8",
+ *  "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640"
+ * ])
+ * // => [{ id, feeTier, totalValueLockedUSD, token0, token1, ... }]
+ */
+export async function fetchWatchedPools(poolIds) {
+  const data = await client.request(GET_WATCHED_POOLS_QUERY, { ids: poolIds })
+  return data.pools
+}
+
+/**
  * Service: Batch-fetches 14-day historical data for sparkline rendering.
  *
  * @param {string[]} poolAddresses - Array of pool contract addresses


### PR DESCRIPTION
## What
End-to-end authentication and personal watchlist for DeFi Scout. Users can create an account or sign in via email/password or Google OAuth, star pools from any page, and access their saved pools at `/watchlist`.

## Why
Portfolio differentiator: Transforms DeFi Scout from a read-only data tool into a personalized app. Demonstrates Firebase Auth (email + OAuth 2.0), Firestore read/write, protected routes, and cross-page state management via React context API and React Router layout routes.

## Changes
- `AuthContext` + `useAuth`: tri-state `currentUser` (null/false/object), modal open/close controls, `onAuthStateChanged` subscription
- `AuthModal`: email/password + Google OAuth (`signInWithPopup`), login/signup toggle, `mapFirebaseError` dictionary, loading states
- `useFavorites`: one-time Firestore fetch on login, optimistic Set updates, `toggleFavorite` opens auth modal if unauthenticated
- `FavoritesLayout`: pathless route calls `useFavorites` once, shares state via `useOutletContext` to `/pools`, `/pools/:poolId`, `/watchlist`
- Star toggle in `PoolTable` (inside sticky name cell) and `PoolDetail` header
- `StarIcons`: extracted `FilledStarIcon` + `OutlinedStarIcon` to shared component
- `watchlistLoader`: hard redirect if unauthenticated; two-phase fetch (Firestore IDs -> TheGraph live data); short-circuits if watchlist empty
- `Watchlist` page: PoolTable + sparklines (no freemium gate) + pagination

## Fixes
- `mapFirebaseError` moved outside component (prevented recreation on each render)
- `label/htmlFor` semantic fix on AuthModal inputs

## Deferred
- Password reset flow -> `feat/password-reset`
- Login/logout button in nav -> polish/branding branch