### PR TITLE
Fix/ux polish v1

### DIFF
--- a/src/components/common/AuthModal.jsx
+++ b/src/components/common/AuthModal.jsx
@@ -221,7 +221,7 @@ export function AuthModal() {
 
                   <button
                     type="button"
-                    className="btn btn-ghost btn-glass rounded-xl text-sm text-base-content/60 mt-4 block mx-auto"
+                    className="text-sm text-base-content/60 hover:text-base-content/80 transition-colors my-6 block mx-auto cursor-pointer"
                     onClick={() => {
                       setMode(mode === MODE.LOGIN ? MODE.SIGNUP : MODE.LOGIN)
                       setError(null)

--- a/src/components/common/AuthModal.jsx
+++ b/src/components/common/AuthModal.jsx
@@ -92,7 +92,7 @@ export function AuthModal() {
     <dialog className={`modal ${isAuthModalOpen ? 'modal-open' : ''}`}>
       <div className="modal-box max-w-xl glass-modal rounded-2xl">
         <button
-          className="btn btn-ghost btn-sm btn-circle btn-glass absolute right-2 top-2"
+          className="btn btn-sm btn-circle btn-glass absolute right-2 top-2 text-sm"
           onClick={handleClose}
         >
           ✕

--- a/src/components/common/AuthModal.jsx
+++ b/src/components/common/AuthModal.jsx
@@ -150,7 +150,7 @@ export function AuthModal() {
                       {mode === MODE.LOGIN && (
                         <button
                           type="button"
-                          className="link-primary -mb-2"
+                          className="link-primary -mb-2 cursor-pointer"
                           onClick={() => setMode(MODE.FORGOT)}
                         >
                           Forgot password?
@@ -192,7 +192,7 @@ export function AuthModal() {
               {mode === MODE.FORGOT ? (
                 <button
                   type="button"
-                  className="btn btn-ghost text-sm text-base-content/60 mt-4 block mx-auto"
+                  className="text-sm text-base-content/60 hover:text-base-content/80 transition-colors mt-6 block mx-auto cursor-pointer"
                   onClick={() => {
                     setMode(MODE.LOGIN)
                     setResetSent(false)

--- a/src/components/common/Dropdown.jsx
+++ b/src/components/common/Dropdown.jsx
@@ -59,10 +59,10 @@ export function Dropdown({ selected, onToggle, options }) {
 
       {/* Menu: Floating list of checkboxes */}
       {isOpen && (
-        <ul className="absolute z-20 mt-2 menu p-2 glass-overlay rounded-3xl w-52">
+        <ul className="absolute z-20 mt-2 menu p-2 glass-overlay rounded-2xl w-52">
           {options.map((option) => (
             <li key={option.value}>
-              <label className="label cursor-pointer">
+              <label className="label cursor-pointer rounded-xl">
                 <input
                   type="checkbox"
                   className="checkbox checkbox-sm"

--- a/src/components/common/MiniSparkline.jsx
+++ b/src/components/common/MiniSparkline.jsx
@@ -1,3 +1,5 @@
+import { CHART_COLORS } from '../../constants/chartColors'
+
 /**
  * UI: Lightweight Trend Visualizer (Sparkline).
  *
@@ -34,8 +36,11 @@ export function MiniSparkline({ data, width = 80, height = 20 }) {
   const last = values[values.length - 1]
 
   // Financial convention: Green (gains), Red (losses), Gray (flat)
-  const strokeColor =
-    last > first ? '#10b981' : last < first ? '#ef4444' : '#6b7280'
+  const strokeColor = last > first
+    ? CHART_COLORS.trend.up
+    : last < first
+      ? CHART_COLORS.trend.down
+      : CHART_COLORS.trend.flat
 
   /**
    * Geometry: Map a numeric value to an SVG Y-coordinate.

--- a/src/components/common/PaginationControls.jsx
+++ b/src/components/common/PaginationControls.jsx
@@ -29,7 +29,7 @@ export function PaginationControls({ currentPage, totalPages, onPageChange }) {
 
   return (
     <div className="flex items-center justify-center gap-2 py-3">
-      <button onClick={goToPrev} disabled={isFirstPage} className="btn btn-sm btn-glass">
+      <button onClick={goToPrev} disabled={isFirstPage} className="btn btn-sm btn-glass rounded-xl">
         ←
       </button>
 
@@ -56,7 +56,7 @@ export function PaginationControls({ currentPage, totalPages, onPageChange }) {
             <button
               key={page}
               onClick={() => goToPage(page)}
-              className={`btn btn-sm btn-glass ${page === currentPage ? 'btn-active' : ''}`}
+              className={`btn btn-sm btn-glass rounded-xl ${page === currentPage ? 'btn-active' : ''}`}
             >
               {page}
             </button>
@@ -64,7 +64,7 @@ export function PaginationControls({ currentPage, totalPages, onPageChange }) {
         })}
       </div>
 
-      <button onClick={goToNext} disabled={isLastPage} className="btn btn-sm btn-glass">
+      <button onClick={goToNext} disabled={isLastPage} className="btn btn-sm btn-glass rounded-xl">
         →
       </button>
     </div>

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -36,7 +36,7 @@ export function Layout() {
       </main>
       <footer className="glass-surface border-t-(--border-subtle) w-full md:rounded-t-3xl">
         <div className="flex flex-col md:flex-row items-center justify-between py-4 px-6">
-          <Link to="/" className="btn btn-ghost text-sm text-primary">
+          <Link to="/" className="btn btn-ghost text-sm text-primary rounded-xl">
             DeFi Scout
           </Link>
           <div className="flex gap-6 items-center">

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -39,13 +39,13 @@ export function Navbar() {
     <header className="navbar glass-surface sticky top-0 z-50 px-0 sm:px-2 md:px-2 md:rounded-b-3xl">
       <div className="flex-1">
         {/* Brand: Larger text-xl for visual hierarchy */}
-        <Link to="/" className="btn btn-ghost text-xl">
+        <Link to="/" className="btn btn-ghost text-xl rounded-xl">
           DeFi Scout
         </Link>
       </div>
       <div className="flex flex-none items-center gap-2 pr-2">
         {/* Primary routes: Ghost buttons for understated navigation */}
-        <Link to="/" className="btn btn-ghost">
+        <Link to="/" className="btn btn-ghost rounded-xl">
           Pools
         </Link>
 
@@ -55,7 +55,7 @@ export function Navbar() {
 
         {currentUser === false && (
           <button
-            className="btn btn-sm btn-primary mr-2"
+            className="btn btn-sm btn-primary mr-2 rounded-xl"
             onClick={() => {
               openAuthModal()
             }}
@@ -90,13 +90,13 @@ export function Navbar() {
                 <div className="absolute flex flex-col items-center z-50 right-0 top-full glass-overlay rounded-xl gap-2 md:gap-0 p-4 md:p-2 mt-2">
                   <Link
                     to="/watchlist"
-                    className="btn btn-ghost text-lg md:text-sm"
+                    className="btn btn-ghost text-lg md:text-sm rounded-xl"
                     onClick={() => setIsOpen(false)}
                   >
                     Watchlist
                   </Link>
                   <button
-                    className="btn btn-ghost text-red-500 text-md md:text-xs whitespace-nowrap"
+                    className="btn btn-ghost text-red-500 text-md md:text-xs whitespace-nowrap rounded-xl"
                     onClick={logout}
                   >
                     Log out

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -39,7 +39,7 @@ export function Navbar() {
     <header className="navbar glass-surface sticky top-0 z-50 px-0 sm:px-2 md:px-2 md:rounded-b-3xl">
       <div className="flex-1">
         {/* Brand: Larger text-xl for visual hierarchy */}
-        <Link to="/" className="btn btn-ghost text-xl rounded-xl">
+        <Link to="/" className="btn btn-ghost text-xl rounded-xl ml-3">
           DeFi Scout
         </Link>
       </div>
@@ -55,7 +55,7 @@ export function Navbar() {
 
         {currentUser === false && (
           <button
-            className="btn btn-sm btn-primary mr-2 rounded-xl"
+            className="btn btn-sm btn-primary mr-1 rounded-xl"
             onClick={() => {
               openAuthModal()
             }}

--- a/src/components/pool-detail/ContractLinks.jsx
+++ b/src/components/pool-detail/ContractLinks.jsx
@@ -50,13 +50,13 @@ export function ContractLinks({ pool, chain = "ethereum" }) {
 
   return (
     <div className="rounded-2xl glass-surface p-4">
-      <div className="text-xs text-base-content/60 mb-1">CONTRACTS</div>
+      <div className="text-sm font-semibold mb-1">Contracts</div>
       {items.map((item) => (
         <div key={item.id} className="flex items-center justify-between gap-2 mt-1">
           <span className="text-sm">{item.label}</span>
           <div>
             <button
-              className="btn btn-ghost btn-xs btn-circle"
+              className="btn btn-glass btn-xs btn-circle mr-2"
               onClick={() => {handleCopy(item.id, item.address)}}
             >
               {copiedId === item.id ? <CheckIcon /> : <CopyIcon />}

--- a/src/components/pool-detail/ContractLinks.jsx
+++ b/src/components/pool-detail/ContractLinks.jsx
@@ -56,7 +56,7 @@ export function ContractLinks({ pool, chain = "ethereum" }) {
           <span className="text-sm">{item.label}</span>
           <div>
             <button
-              className="btn btn-ghost btn-xs"
+              className="btn btn-ghost btn-xs btn-circle"
               onClick={() => {handleCopy(item.id, item.address)}}
             >
               {copiedId === item.id ? <CheckIcon /> : <CopyIcon />}

--- a/src/components/pool-detail/CurrentPriceCard.jsx
+++ b/src/components/pool-detail/CurrentPriceCard.jsx
@@ -39,7 +39,7 @@ export function CurrentPriceCard({ pool, selectedTokenIdx, onTokenChange }) {
         </div>
       )}
 
-      <div className="join">
+      <div className="join mt-4">
         <button
           className={`btn btn-glass rounded-l-xl join-item ${selectedTokenIdx === 0 ? 'btn-active' : ''}`}
           onClick={() => {onTokenChange(0)}}

--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -182,7 +182,7 @@ export function PoolDetail() {
   return (
     <div className="container mx-auto px-4 pt-4 max-w-7xl">
       {/* NAVIGATION: Contextual return */}
-      <Link to="/" className="btn btn-ghost btn-sm mb-6 gap-2">
+      <Link to="/" className="btn btn-ghost btn-sm mb-6 gap-2 rounded-xl">
         <span>←</span>
         <span>Back to Pools</span>
       </Link>

--- a/src/components/pool-detail/calculator/CalculatorInputs.jsx
+++ b/src/components/pool-detail/calculator/CalculatorInputs.jsx
@@ -104,7 +104,7 @@ export function CalculatorInputs({
 
       {/* Price Range Configuration */}
       <div className="mb-6">
-        <div className="flex justify-between items-center mb-2">
+        <div className="flex justify-between items-center mb-2 md:mb-4">
           <label className="text-sm font-semibold">Price Range</label>
           <label className="flex items-center gap-2 cursor-pointer">
             <span className="text-sm">Full Range:</span>
@@ -119,7 +119,7 @@ export function CalculatorInputs({
 
         {/* Volatility Presets
           Disabled when fullRange=true (liquidity spans 0 to ∞, no discrete bounds) */}
-        <div className="flex gap-2 mb-3">
+        <div className="flex gap-2 mb-3 md:mb-6">
           <button
             type="button"
             onClick={() => onPresetClick('±10%')}
@@ -150,22 +150,22 @@ export function CalculatorInputs({
         <div className="grid grid-cols-2 gap-3 mb-3">
           <div className="form-control glass-surface rounded-xl p-3">
             <div className="flex justify-between items-center mb-1">
-              <label className="text-xs text-base-content/60">Min Price</label>
-              <div className="flex gap-1">
+              <div className="flex justify-between flex-1 items-center gap-1 mb-1">
                 <button
                   type="button"
                   onClick={() => onIncrement('minPrice', -1)}
                   disabled={inputs.fullRange}
-                  className="btn btn-xs btn-circle btn-ghost glass-input"
+                  className="btn btn-sm md:btn-xs btn-circle btn-glass"
                   title="Decrease by 1 tick spacing"
                 >
                   −
                 </button>
+                <label className="text-xs text-base-content/60">Min Price</label>
                 <button
                   type="button"
                   onClick={() => onIncrement('minPrice', 1)}
                   disabled={inputs.fullRange}
-                  className="btn btn-xs btn-circle btn-ghost glass-input"
+                  className="btn btn-sm md:btn-xs btn-circle btn-glass"
                   title="Increase by 1 tick spacing"
                 >
                   +
@@ -190,22 +190,22 @@ export function CalculatorInputs({
 
           <div className="form-control glass-surface rounded-xl p-3">
             <div className="flex justify-between items-center mb-1">
-              <label className="text-xs text-base-content/60">Max Price</label>
-              <div className="flex gap-1">
+              <div className="flex justify-between flex-1 items-center gap-1 mb-1">
                 <button
                   type="button"
                   onClick={() => onIncrement('maxPrice', -1)}
                   disabled={inputs.fullRange}
-                  className="btn btn-xs btn-circle btn-ghost glass-input"
+                  className="btn btn-sm md:btn-xs btn-circle btn-glass"
                   title="Decrease by 1 tick spacing"
                 >
                   −
                 </button>
+                <label className="text-xs text-base-content/60">Max Price</label>
                 <button
                   type="button"
                   onClick={() => onIncrement('maxPrice', 1)}
                   disabled={inputs.fullRange}
-                  className="btn btn-xs btn-circle btn-ghost glass-input"
+                  className="btn btn-sm md:btn-xs btn-circle btn-glass"
                   title="Increase by 1 tick spacing"
                 >
                   +
@@ -232,35 +232,36 @@ export function CalculatorInputs({
         {/* Assumed Entry Price for Simulation */}
         <div className="glass-surface rounded-xl p-3">
           <div className="flex justify-between items-center mb-2 gap-2">
-            <div className="flex items-center">
-              <span className="text-xs text-base-content/60 pr-2">
-                Assumed Entry Price
-              </span>
-              <button className="btn btn-circle btn-glass btn-xs">
-                <div
-                  className="tooltip tooltip-bottom"
-                  data-tip="It first populates with the most recent price for the pool. You can adjust your desired entry price for the range calculator."
-                >
-                  <div className="font-medium text-base-content max-w-[120px] truncate">
-                    ?
-                  </div>
-                </div>
-              </button>
-            </div>
-
-            <div className="flex items-center gap-1">
+            <div className="flex justify-between flex-1 items-center gap-1">
               <button
                 type="button"
                 onClick={() => onIncrement('assumedPrice', -1)}
-                className="btn btn-xs btn-circle btn-ghost glass-input"
+                className="btn btn-sm md:btn-xs btn-circle btn-glass"
                 title="Decrease by 1 tick spacing"
               >
                 −
               </button>
+
+              <div className="flex justify-center flex-1 items-center gap-1">
+                <span className="text-xs text-base-content/60 pr-1">
+                  Assumed Entry Price
+                </span>
+                <button className="btn btn-circle btn-glass btn-xs">
+                  <div
+                    className="tooltip tooltip-top before:max-w-60 before:whitespace-normal"
+                    data-tip="It first populates with the most recent price for the pool. You can adjust your desired entry price for the range calculator."
+                  >
+                    <div className="font-medium text-base-content max-w-[120px] truncate">
+                      ?
+                    </div>
+                  </div>
+                </button>
+              </div>
+
               <button
                 type="button"
                 onClick={() => onIncrement('assumedPrice', 1)}
-                className="btn btn-xs btn-circle btn-ghost glass-input"
+                className="btn btn-sm md:btn-xs btn-circle btn-glass"
                 title="Increase by 1 tick spacing"
               >
                 +

--- a/src/components/pool-detail/calculator/CalculatorInputs.jsx
+++ b/src/components/pool-detail/calculator/CalculatorInputs.jsx
@@ -248,7 +248,7 @@ export function CalculatorInputs({
               </button>
             </div>
 
-            <div className="flex items-center">
+            <div className="flex items-center gap-1">
               <button
                 type="button"
                 onClick={() => onIncrement('assumedPrice', -1)}

--- a/src/components/pool-detail/calculator/CalculatorInputs.jsx
+++ b/src/components/pool-detail/calculator/CalculatorInputs.jsx
@@ -27,7 +27,8 @@ export function CalculatorInputs({
   token0Symbol,
   token1Symbol,
   composition,
-  selectedTokenIdx
+  selectedTokenIdx,
+  positionUrl
 }) {
   const token0Amount = composition?.amount0
   const token1Amount = composition?.amount1
@@ -286,9 +287,17 @@ export function CalculatorInputs({
       </div>
 
       {/* Protocol deep-link */}
-      <button className="btn btn-error text-base-content w-full rounded-xl">
-        Create Position on Uniswap →
-      </button>
+      <a
+        href={positionUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="btn btn-error text-base-content w-full rounded-xl"
+      >
+        Create Position on Uniswap
+        <svg xmlns="http://www.w3.org/2000/svg" width="1.25em" height="1.25em" viewBox="0 0 24 24">
+          <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.6" d="M12 6H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6m-7 1l9-9m-5 0h5v5"/>
+        </svg>
+      </a>
     </div>
   )
 }

--- a/src/components/pool-detail/calculator/ILProjectionModal.jsx
+++ b/src/components/pool-detail/calculator/ILProjectionModal.jsx
@@ -53,7 +53,7 @@ export function ILProjectionModal({
         {/* Header */}
         <div className="flex justify-between items-center mb-6">
           <h3 className="text-2xl font-bold">Simulate Position Performance</h3>
-          <button onClick={onClose} className="btn btn-sm btn-circle btn-ghost">
+          <button onClick={onClose} className="btn btn-sm btn-circle btn-glass">
             x
           </button>
         </div>

--- a/src/components/pool-detail/calculator/RangeCalculator.jsx
+++ b/src/components/pool-detail/calculator/RangeCalculator.jsx
@@ -5,6 +5,7 @@ import { simulateRangePerformance } from './utils/simulateRangePerformance'
 import { calculatePresetRange } from './utils/calculatePresetRange'
 import { calculateTokenPrices } from './utils/calculateTokenPrices'
 import { incrementPriceByTick } from './utils/uniswapV3Ticks'
+import { buildUniswapPositionUrl } from '../../../utils/buildUniswapPositionUrl'
 import { debugLog } from '../../../utils/logger'
 
 /**
@@ -125,6 +126,12 @@ export function RangeCalculator({
     })
   }, [inputs, selectedTokenIdx, hourlyData, pool, ethPriceUSD])
 
+  const composition = results?.composition || null
+  const positionUrl = useMemo(
+    () => buildUniswapPositionUrl(pool, inputs, composition, selectedTokenIdx),
+    [pool, inputs, composition, selectedTokenIdx]
+  )
+
   return (
     <div className="grid gap-6">
       <div className="flex flex-col gap-4">
@@ -150,7 +157,8 @@ export function RangeCalculator({
             priceLabel={priceLabel}
             token0Symbol={pool.token0.symbol}
             token1Symbol={pool.token1.symbol}
-            composition={results?.composition || null}
+            positionUrl={positionUrl}
+            composition={composition}
             selectedTokenIdx={selectedTokenIdx}
           />
         </div>

--- a/src/components/pool-detail/charts/TVLVolumeChart.jsx
+++ b/src/components/pool-detail/charts/TVLVolumeChart.jsx
@@ -88,8 +88,9 @@ export function TVLVolumeChart({ history }) {
             type="monotone"
             dataKey="tvlUSD"
             fill={CHART_COLORS.dataViz.tvl}
-            stroke={CHART_COLORS.dataViz.tvl}
-            fillOpacity={0.3}
+            stroke={CHART_COLORS.primary}
+            fillOpacity={0.15}
+            strokeOpacity={0.5}
             name="TVL"
           />
 
@@ -97,7 +98,7 @@ export function TVLVolumeChart({ history }) {
           <Bar
             yAxisId="right"
             dataKey="volumeUSD"
-            fill={CHART_COLORS.dataViz.volume}
+            fill={CHART_COLORS.dataViz.tvl}
             opacity={0.8}
             name="Volume"
           />

--- a/src/components/pools/PoolFilters.jsx
+++ b/src/components/pools/PoolFilters.jsx
@@ -94,7 +94,7 @@ export function PoolFilters({
       <div
         className={`fixed bottom-0 left-0 right-0 z-50 md:hidden glass-modal
           rounded-t-4xl transition-transform duration-300 ease-out
-          ${isOpen ? 'translate-y-0' : 'translate-y-full'}`}
+          ${isOpen ? 'translate-y-0' : 'translate-y-[140%]'}`}
       >
         <div className="p-4">
           <div className="w-12 h-1 bg-base-300 rounded-full mx-auto mb-4" />

--- a/src/components/pools/PoolFilters.jsx
+++ b/src/components/pools/PoolFilters.jsx
@@ -99,7 +99,7 @@ export function PoolFilters({
         <div className="p-4">
           <div className="w-12 h-1 bg-base-300 rounded-full mx-auto mb-4" />
           <button
-            className="btn btn-ghost absolute top-4 right-4 mb-4"
+            className="btn btn-sm btn-circle btn-glass absolute top-4 right-4 mb-4 text-sm"
             onClick={() => {setIsOpen(false)}}
           >
             ✕
@@ -131,7 +131,7 @@ export function PoolFilters({
                 onChange={(e) => updateLocalFilter('volumeUsd1d', e.target.value)}
               />
 
-              <button onClick={handleClearFilters} className="btn btn-sm btn-ghost rounded-xl">
+              <button onClick={handleClearFilters} className="btn btn-sm btn-glass rounded-xl">
                 Clear filters
               </button>
             </div>
@@ -160,7 +160,7 @@ export function PoolFilters({
         className="hidden md:block input glass-input input-sm rounded-xl w-36"
         onChange={(e) => updateLocalFilter('volumeUsd1d', e.target.value)}
       />
-      <button onClick={handleClearFilters} className="hidden md:block btn btn-sm btn-glass">
+      <button onClick={handleClearFilters} className="hidden md:block btn btn-sm btn-glass rounded-xl">
         Clear filters
         <span
           className={`ml-2 ${activeCount < 1 ? 'hidden' : 'badge badge-xs badge-primary'}`}

--- a/src/components/pools/PoolFilters.jsx
+++ b/src/components/pools/PoolFilters.jsx
@@ -131,7 +131,7 @@ export function PoolFilters({
                 onChange={(e) => updateLocalFilter('volumeUsd1d', e.target.value)}
               />
 
-              <button onClick={handleClearFilters} className="btn btn-sm btn-ghost">
+              <button onClick={handleClearFilters} className="btn btn-sm btn-ghost rounded-xl">
                 Clear filters
               </button>
             </div>
@@ -160,7 +160,7 @@ export function PoolFilters({
         className="hidden md:block input glass-input input-sm rounded-xl w-36"
         onChange={(e) => updateLocalFilter('volumeUsd1d', e.target.value)}
       />
-      <button onClick={handleClearFilters} className="hidden md:block btn btn-sm btn-glass rounded-xl">
+      <button onClick={handleClearFilters} className="hidden md:block btn btn-sm btn-glass">
         Clear filters
         <span
           className={`ml-2 ${activeCount < 1 ? 'hidden' : 'badge badge-xs badge-primary'}`}

--- a/src/components/pools/PoolTable.jsx
+++ b/src/components/pools/PoolTable.jsx
@@ -129,7 +129,7 @@ const PoolTable = forwardRef(
           return {
             ...col,
             cell: ({ row }) => (
-              <div className="text-right font-semibold text-green-600">
+              <div className="text-right font-semibold text-success">
                 {Number(row.original.apyBase || 0).toFixed(2)}%
               </div>
             )

--- a/src/constants/chartColors.js
+++ b/src/constants/chartColors.js
@@ -9,7 +9,6 @@
  * - primary   -> --color-error   (assumed price reference line)
  * - secondary -> --color-success (range boundary reference lines)
  * - dataViz.tvl / .volume / .price -> --color-primary
- * - dataViz.fees                   -> --color-success
  *
  * @constant {Object} CHART_COLORS
  * @property {string} primary - Assumed price reference line color
@@ -20,22 +19,28 @@
  * @property {Object} tooltip - Tooltip container styling
  */
 export const CHART_COLORS = {
-  primary:   'oklch(0.63 0.22 15)',    // --color-error
-  secondary: 'oklch(0.67 0.18 162)',   // --color-success
+  primary:   'oklch(0.63 0.22 15)',           // --color-error
+  secondary: 'oklch(0.7273 0.1429 170.56)',   // --color-success
 
-  grid: '#1a2035',
-  axis: '#94a3b8',
+  grid: 'oklch(0.2486 0.041 271.04)',
+  axis: 'oklch(0.7107 0.0351 256.79)',
 
   dataViz: {
-    tvl:    'oklch(0.56 0.22 264)',    // --color-primary
-    volume: 'oklch(0.56 0.22 264)',    // --color-primary
-    fees:   'oklch(0.67 0.18 162)',    // --color-success
-    price:  'oklch(0.56 0.22 264)',    // --color-primary
+    liquidity: 'oklch(0.50 0.26 280)',           // --color-secondary
+    tvl:       'oklch(0.5854 0.2041 277.12)',    // --color-primary
+    volume:    'oklch(0.5854 0.2041 277.12)',    // --color-primary
+    price:     'oklch(0.5854 0.2041 277.12)',    // --color-primary
+  },
+
+  trend: {
+    up:   'oklch(0.7273 0.1429 170.56)',  // --color-success
+    down: 'oklch(0.63 0.22 15)',          // --color-error
+    flat: 'oklch(0.5544 0.0407 257.42)'   // neutral gray
   },
 
   tooltip: {
-    bg:     '#0f1628',
-    border: '#1e2a45',
-    text:   '#e2e8f0'
+    bg:     'oklch(0.2035 0.0377 266.94)',
+    border: 'oklch(0.2882 0.0525 265.09)',
+    text:   'oklch(0.9288 0.0126 255.51)'
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -24,13 +24,14 @@
   --color-base-content: oklch(0.91 0.01 265);
 
   /* INTERACTIVE */
-  --color-primary: oklch(0.56 0.22 264);
+  /* --color-primary: oklch(0.56 0.22 264); */
+  --color-primary: oklch(0.5854 0.2041 277.12);
   --color-primary-content: oklch(1 0 0);
   --color-secondary: oklch(0.50 0.26 280);
   --color-secondary-content: oklch(1 0 0);
 
   /* SEMANTIC */
-  --color-success: oklch(0.67 0.18 162);
+  --color-success: oklch(0.7273 0.1429 170.56);
   --color-warning: oklch(0.75 0.18 80);
   --color-error: oklch(0.63 0.22 15);
   --color-info: oklch(0.56 0.22 264);

--- a/src/index.css
+++ b/src/index.css
@@ -81,6 +81,9 @@
   .sticky-column-shadow {
     box-shadow: 5px 0 20px -10px rgba(0, 0, 0, 0.3);
   }
+  .tooltip::before {
+    border-radius: 0.75rem; /* rounded-xl */
+  }
 
   /* Glass Surfaces */
   .glass-surface {

--- a/src/utils/buildUniswapPositionUrl.js
+++ b/src/utils/buildUniswapPositionUrl.js
@@ -1,0 +1,84 @@
+import { priceToTick, alignTickToSpacing, getTickSpacing } from '../components/pool-detail/calculator/utils/uniswapV3Ticks'
+
+const MIN_TICK = -887272
+const MAX_TICK = 887272
+
+/**
+ * Utility: Builds a URL to auto-populate a Uniswap V3 position creation form.
+ *
+ * @param {Object} pool - Pool data from TheGraph (token ids, chain, feeTier)
+ * @param {Object} inputs - User-defined range state (fullRange, minPrice, maxPrice, assumedPrice)
+ * @param {Object|null} [composition] - Token split from simulation pipeline (null during computation)
+ * @param {number} selectedTokenIdx - Active token perspective (0=token0, 1=token1)
+ * @returns {string} URL to create a Uniswap V3 position
+ */
+export function buildUniswapPositionUrl(pool, inputs, composition, selectedTokenIdx) {
+  const token0Address = pool.token0.id.toLowerCase()
+  const token1Address = pool.token1.id.toLowerCase()
+
+  const decimals0 = Number(pool.token0.decimals)
+  const decimals1 = Number(pool.token1.decimals)
+  const decimalAdjustment = Math.pow(10, decimals1 - decimals0)
+
+  const tickSpacing = getTickSpacing(pool.feeTier)
+  const priceInverted = selectedTokenIdx === 0
+
+  let minTick, maxTick
+
+  if (inputs.fullRange) {
+    minTick = Math.ceil(MIN_TICK / tickSpacing) * tickSpacing
+    maxTick = Math.floor(MAX_TICK / tickSpacing) * tickSpacing
+  } else {
+    const canonicalMin = selectedTokenIdx === 1 ? 1 / inputs.maxPrice : inputs.minPrice
+    const canonicalMax = selectedTokenIdx === 1 ? 1 / inputs.minPrice : inputs.maxPrice
+
+    const canonicalMinTick = alignTickToSpacing(priceToTick(decimalAdjustment / canonicalMax), tickSpacing)
+    const canonicalMaxTick = alignTickToSpacing(priceToTick(decimalAdjustment / canonicalMin), tickSpacing)
+
+    if (priceInverted) {
+      minTick = -canonicalMaxTick
+      maxTick = -canonicalMinTick
+    } else {
+      minTick = canonicalMinTick
+      maxTick = canonicalMaxTick
+    }
+  }
+
+  const fee = JSON.stringify({
+    feeAmount: pool.feeTier,
+    tickSpacing
+  })
+
+  const priceRangeState = JSON.stringify({
+    priceInverted,
+    fullRange: !!inputs.fullRange,
+    minTick,
+    maxTick,
+    initialPrice: inputs.fullRange ? '' : String(inputs.assumedPrice),
+    inputMode: 'price'
+  })
+
+  const depositState = JSON.stringify({
+    isInternal: false,
+    exactField: 'TOKEN0',
+    exactAmounts: composition ? {
+      TOKEN0: isFinite(composition.amount0) ? composition.amount0.toFixed(8) : '0',
+      TOKEN1: isFinite(composition.amount1) ? composition.amount1.toFixed(8) : '0'
+    } : {}
+  })
+
+  const [c0, c1] = token0Address < token1Address
+    ? [token0Address, token1Address]
+    : [token1Address, token0Address]
+
+  const params = new URLSearchParams()
+  params.set('currencyA', c0)
+  params.set('currencyB', c1)
+  params.set('chain', 'ethereum')
+  params.set('fee', fee)
+  params.set('hook', 'undefined')
+  params.set('priceRangeState', priceRangeState)
+  params.set('depositState', depositState)
+
+  return `https://app.uniswap.org/positions/create/v3?${params.toString()}`
+}


### PR DESCRIPTION
Closes #36 

## Summary
UX polish pass covering visual consistency, mobile usability fixes, and Uniswap V3 position deep linking

## Changes

### Visual Consistency
- Normalized success color to `#02C39A / oklch(0.7273 0.1429 170.56)` and chart palette to oklch across all components
- Global radius pass: `rounded-xl` applied to buttons, footer, pagination, dropdown, contract links
- Removed `btn-glass` from `AuthModal` mode-toggle (style conflict)
- Top margin added to `CurrentPriceCard` join buttons

### Mobile Fixes
- Increased stepper tap targets for thumb-friendly interaction
- Fixed tooltip overflow and border radius on mobile
- Added horizontal padding to assumed price +/- stepper buttons
- Fixed `ContractLinks` button styles and spacing
- Increased bottom sheet hide offset to 140% to fix sliver visibility on iOS (safe area inset issue – confirmed on iPhone 15 Pro)

### Uniswap V3 Deep Linking
- Added `buildUniswapPositionUrl` utility: generates a pre-filled Uniswap V3 position URL from pool address, token addresses, fee tier, and tick range
- Fixed tick formula: corrected `decimalAdjustment / canonicalPrice` inversion
- Fixed `priceInverted` convention to match Uniswap's token ordering (token1 terms by default)

## Testing
- ✔️ Visual pass on desktop
- ✔️ Visual pass on mobile (real device)
- ✔️ Uniswap position URL opens with correct range pre-filled