### PR TITLE
Feat/pool detail polish

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -24,9 +24,9 @@ export function Layout() {
   const isLoading = navigation.state === 'loading'
 
   return (
-    <div className="site-wrapper max-w-5xl mx-auto">
+    <div className="site-wrapper min-h-dvh max-w-5xl mx-auto flex flex-col">
       <Navbar />
-      <main className="min-h-screen p-0 sm:px-2 md:p-6">
+      <main className="flex-1 p-0 sm:px-2 md:p-6 mb-4 md:mb-0">
         {isLoading && (
           <div className="fixed top-20 right-4 z-50">
             <span className="loading loading-spinner loading-lg"></span>

--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -1,4 +1,4 @@
-import { useLoaderData, Link, useOutletContext } from 'react-router-dom'
+import { useLoaderData, Link, useOutletContext, useLocation } from 'react-router-dom'
 import { useCallback, useEffect, useState, useRef } from 'react'
 import { ContractLinks } from './ContractLinks'
 import { CurrentPriceCard } from './CurrentPriceCard'
@@ -51,6 +51,7 @@ export function PoolDetail() {
     maxPrice: '',
     assumedPrice: ''
   })
+  const { state } = useLocation()
 
   /**
    * Hydration: Initializes price range from on-chain liquidity distribution.
@@ -179,12 +180,18 @@ export function PoolDetail() {
   // Check if pool is in the user's watchlist
   const isFavorited = favoriteIds.has(pool.id)
 
+  // Check if user comes from watchlist
+  const fromWatchlist = state?.from === 'watchlist'
+
   return (
     <div className="container mx-auto px-4 pt-4 max-w-7xl">
       {/* NAVIGATION: Contextual return */}
-      <Link to="/" className="btn btn-ghost btn-sm mb-6 gap-2 rounded-xl">
+      <Link
+        to={fromWatchlist ? '/watchlist' : '/'}
+        className="btn btn-ghost btn-sm mb-6 gap-2 rounded-xl"
+      >
         <span>←</span>
-        <span>Back to Pools</span>
+        <span>{`Back to ${fromWatchlist ? 'Watchlist' : 'Pools'}`}</span>
       </Link>
 
       {/* Header: Identity and protocol info */}

--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -298,9 +298,11 @@ export function PoolDetail() {
             fetchError={fetchError}
             ethPriceUSD={ethPriceUSD}
           />
-          <ContractLinks
-            pool={pool}
-          />
+          <div className="hidden md:block mb-4">
+            <ContractLinks
+              pool={pool}
+            />
+          </div>
         </div>
 
         <div className="md:col-start-3 md:col-span-3 md:row-start-2">
@@ -314,6 +316,11 @@ export function PoolDetail() {
             currentPrice={currentPrice}
             tickData={tickData}
             tickError={tickError}
+          />
+        </div>
+        <div className="md:hidden mb-4">
+          <ContractLinks
+            pool={pool}
           />
         </div>
       </div>

--- a/src/components/pools/PoolTable.jsx
+++ b/src/components/pools/PoolTable.jsx
@@ -54,7 +54,8 @@ const PoolTable = forwardRef(
       sorting,
       onSortingChange,
       favoriteIds,
-      toggleFavorite
+      toggleFavorite,
+      from
     },
     ref
   ) => {
@@ -103,6 +104,7 @@ const PoolTable = forwardRef(
 
                   <Link
                     to={`/pools/${row.original.id}`}
+                    state={{ from }}
                     className="flex items-center gap-2"
                     aria-label={`View details for ${row.original.name} pool`}
                   >
@@ -206,7 +208,7 @@ const PoolTable = forwardRef(
 
         return col
       })
-    }, [sparklineData, favoriteIds, toggleFavorite])
+    }, [sparklineData, favoriteIds, toggleFavorite, from])
 
     const visibleColumns = useMemo(() => {
       return columns.filter((col) => {
@@ -303,7 +305,7 @@ const PoolTable = forwardRef(
           if (e.metaKey || e.ctrlKey) {
             window.open(`/pools/${poolId}`, '_blank')
           } else {
-            navigate(`/pools/${poolId}`)
+            navigate(`/pools/${poolId}`, { state: { from } })
           }
         }
 

--- a/src/components/pools/PoolsContent.jsx
+++ b/src/components/pools/PoolsContent.jsx
@@ -9,7 +9,6 @@ import { PaginationControls } from '../common/PaginationControls'
 import { PoolFilters } from './PoolFilters'
 import { PoolTable } from './PoolTable'
 
-
 /**
  * Component: Pool Data Pipeline Orchestrator
  *

--- a/src/pages/Watchlist.jsx
+++ b/src/pages/Watchlist.jsx
@@ -57,6 +57,7 @@ export default function Watchlist() {
           sorting={sorting}
           onSortingChange={setSorting}
           onVisiblePoolsChange={setVisiblePoolIds}
+          from="watchlist"
         />
           <div className="py-4">
             <PaginationControls


### PR DESCRIPTION
## Summary
Three targeted UX improvements to the pool detail page and global layout

## Changes

### ContractLinks Mobile Order
- Moved `ContractLinks` below `PoolCharts` on mobile to keep calculator inputs visually close to the charts
- Implemented via duplicate visibility toggle (`hidden md:block`/ `md:hidden`) – No DOM restructure needed

### Contextual Back Navigation
- "Back to Pools" now reads "Back to Watchlist" when navigating from `/watchlist`
- Implemented via React Router `state` prop – `from="watchlist` passed through `PoolTable` as a router state
- `PoolDetail` reads `useLocation().state?.from` to conditionally render label and `to` target

### Dynamic Viewport Height
- Replaced `min-h-screen` (`vh`) with `min-h-dvh` + `flex flex-col` on layout wrapper
- `main` gets `flex-1`: eliminates dead space between content and footer on desktop
- `dvh` fixes iOS Safari overflow caused by `vh` overshooting the visible area when address bar is visible
- Confirmed on iPhone 15 Pro (real device)

## Testing
- ✔️ `ContractLinks` appears below charts on mobile, below calculator on desktop
- ✔️ Back navigation reads and routes correctly from both `/pools`and `/watchlist`
- ✔️ No dead space on desktop; no overflow on iOS Safari