### PR TITLE
feat: add Explore Pools CTA to empty watchlist state

### DIFF
--- a/src/pages/Watchlist.jsx
+++ b/src/pages/Watchlist.jsx
@@ -1,4 +1,4 @@
-import { useLoaderData, useOutletContext } from 'react-router-dom'
+import { useLoaderData, useOutletContext, Link } from 'react-router-dom'
 import { useRef, useState, useMemo } from 'react'
 import { PoolTable } from '../components/pools/PoolTable'
 import { PaginationControls } from '../components/common/PaginationControls'
@@ -37,6 +37,8 @@ export default function Watchlist() {
       <div className="flex flex-col items-center justify-center py-32 text-base-content/50">
         <p className="text-lg font-medium">No saved pools yet.</p>
         <p className="text-sm mt-1">Star a pool from the main table to add it here.</p>
+        {/* TODO: update to "/pools" when a landing page is added at "/" */}
+        <Link to="/" className="btn btn-primary rounded-xl mt-4">Explore Pools</Link>
       </div>
     )
   }


### PR DESCRIPTION
### Summary
Improves empty watchlist UX with a direct navigation path back to the pool discovery list.

### Changes
- Added "Explore Pools" CTA button to empty watchlist state
- Routes to `/` (current pools index) with a TODO to update when a landing page is introduced at `/`

### Testing
- ✔️ Remove all favorites -> watchlist shows empty state with CTA
- ✔️ CTA navigates to pool discovery list