### PR TITLE
Fix/pool filters ux

### DIFF
--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -1,8 +1,8 @@
 import {
   useLoaderData,
-  Link,
   useOutletContext,
-  useLocation
+  useLocation,
+  useNavigate
 } from 'react-router-dom'
 import { useCallback, useEffect, useState, useRef } from 'react'
 import { ContractLinks } from './ContractLinks'
@@ -74,6 +74,7 @@ export function PoolDetail() {
     assumedPrice: ''
   })
   const { state } = useLocation()
+  const navigate = useNavigate()
 
   /**
    * Hydration: Initializes price range from on-chain liquidity distribution.
@@ -220,13 +221,13 @@ export function PoolDetail() {
         {`${primary.symbol}/${secondary.symbol} ${(pool.feeTier / 10000).toFixed(2)}% Pool | DeFi Scout`}
       </title>
       {/* NAVIGATION: Contextual return */}
-      <Link
-        to={fromWatchlist ? '/watchlist' : '/'}
+      <button
+        onClick={() => navigate(-1)}
         className="btn btn-ghost btn-sm mb-4 md:mb-6 gap-2 rounded-xl"
       >
         <span>←</span>
         <span>{`Back to ${fromWatchlist ? 'Watchlist' : 'Pools'}`}</span>
-      </Link>
+      </button>
 
       {/* Header: Identity and protocol info */}
       <div className="glass-surface mb-6 rounded-3xl p-6 shadow-lg">

--- a/src/hooks/useDebouncedFilterInputs.js
+++ b/src/hooks/useDebouncedFilterInputs.js
@@ -44,6 +44,14 @@ export function useDebouncedFilterInputs(filters, updateFilter) {
 
   // Race condition guard: prevents debounced values from restoring after manual clear
   const isResetting = useRef(false)
+  const isOurUpdate = useRef(false)
+
+  // Track the latest filters value to prevent infinite loops
+  const filtersRef = useRef(filters)
+
+  useEffect(() => {
+    filtersRef.current = filters
+  }, [filters])
 
   // Effect 1: Propagate debounced values to URL (with reset guard)
   useEffect(() => {
@@ -53,27 +61,31 @@ export function useDebouncedFilterInputs(filters, updateFilter) {
       return
     }
 
-    if (debouncedSearch !== filters.search) {
+    if (debouncedSearch !== filtersRef.current.search) {
+      isOurUpdate.current = true
       updateFilter('search', debouncedSearch)
     }
-    if (debouncedTvl !== filters.tvlUsd) {
+    if (debouncedTvl !== filtersRef.current.tvlUsd) {
+      isOurUpdate.current = true
       updateFilter('tvlUsd', debouncedTvl)
     }
-    if (debouncedVolume !== filters.volumeUsd1d) {
+    if (debouncedVolume !== filtersRef.current.volumeUsd1d) {
+      isOurUpdate.current = true
       updateFilter('volumeUsd1d', debouncedVolume)
     }
   }, [
     debouncedSearch,
     debouncedTvl,
     debouncedVolume,
-    filters.search,
-    filters.tvlUsd,
-    filters.volumeUsd1d,
     updateFilter
   ])
 
   // Effect 2: Sync URL back to local
   useEffect(() => {
+    if (isOurUpdate.current) {
+      isOurUpdate.current = false
+      return
+    }
     setLocalFilters({
       search: filters.search,
       tvlUsd: filters.tvlUsd,


### PR DESCRIPTION
## Problem
Two bugs in the pool filters UX:

1. Rapid delete+retype in the search or number inputs could trigger an intermittent infinite rendering loop. The root cause was a bidirectional sync between two effects: Effect 1 wrote debounced values to the URL, Effect 2 synced the URL back to local state; creating a feedback cycle that closed under fast input conditions.
2. The "Back to Pools" button navigated to `/` (pools, bare path), discarding all active filters from the URL. Browser back worked correctly because it restores the full history entry; the button did not.

## Solution

**Loop Fix:** Introduced two refs to break both feedback paths:
- `filtersRef` - keeps a current copy of filters without adding them to Effect 1's dependency array, so Effect 1 no longer re-runs when the URL it just wrote changes
- `isOurUpdate` - raised inside each update block before calling `updateFilter`; Effect 2 checks this flag and skips the local sync when we caused the URL change, while still syncing for external changes like browser back/forward

**Back Button Fix:** Replaced `<Link to="/">` with `navigate(-1)`, which pops the history stack and restores the previous URL with all params intact.

## Behavior after fix
- ✔️ Spam typing / fast delete+retype no longer triggers render loops
- ✔️ Active filters are preserved when navigating back from a pool detail page
- ✔️ Browser back/forward continues to sync filter inputs correctly 
