### PR TITLE
fix(assessDataQuality): use time span instead of snapshot count for quality tiers

### DIFF
--- a/src/components/pool-detail/calculator/CalculatorStats.jsx
+++ b/src/components/pool-detail/calculator/CalculatorStats.jsx
@@ -106,9 +106,6 @@ export function CalculatorStats({
   const yearlyAPR = results.APR
   const monthlyAPR = yearlyAPR / 12 // Simplified (not compounded) for readability
 
-  // Statistical Confidence: <7 days = small sample, high variance
-  const hasLimitedData = results.daysOfData < 7
-
   return (
     <>
       <h2 className="mb-2 text-lg font-semibold">Estimated Fees (24h)</h2>
@@ -134,13 +131,14 @@ export function CalculatorStats({
         </div>
       </div>
 
-      {/* Data Quality Warning: Low sample size increases projection variance */}
-      {hasLimitedData && (
-        <div className="alert alert-warning mb-4 text-xs">
-          ⚠️ Based on {results.daysOfData.toFixed(1)} days. Projections may
-          vary.
-        </div>
-      )}
+      {/* Data quality warnings from assessDataQuality (LIMITED tier) and anomaly detection */}
+      {results.warnings.length > 0 &&
+        results.warnings.map((warning) => (
+          <div key={warning} className="alert alert-warning mb-4 text-xs">
+            {`⚠️ ${warning}`}
+          </div>
+        ))
+      }
 
       <div className="flex gap-2">
         <button

--- a/src/components/pool-detail/calculator/hooks/usePoolHourlyData.js
+++ b/src/components/pool-detail/calculator/hooks/usePoolHourlyData.js
@@ -27,7 +27,7 @@ import { fetchPoolHourData } from '../../../../services/theGraphClient'
  *    fetchError: string|null
  * }}
  */
-export function usePoolHourlyData(poolId, daysLookback = 7) {
+export function usePoolHourlyData(poolId, daysLookback = 30) {
   const [hourlyData, setHourlyData] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [fetchError, setFetchError] = useState(null)
@@ -59,7 +59,7 @@ export function usePoolHourlyData(poolId, daysLookback = 7) {
           Math.floor(Date.now() / 1000) - fetchDays * 24 * 60 * 60
         const rawData = await fetchPoolHourData(poolId, startTime)
         const data = formatHourlyData(rawData)
-        // slice the last 7 days to avoid inflated APR calculation
+        // slice the last daysLookback days to avoid inflated APR calculation
         const result = data.slice(-(daysLookback * 24))
 
         if (!cancelled) {

--- a/src/components/pool-detail/calculator/pipeline/validateInputs.js
+++ b/src/components/pool-detail/calculator/pipeline/validateInputs.js
@@ -1,14 +1,13 @@
 /**
  * Pipeline Stage: Validates inputs for LP position.
  *
- * @param {Object} params - User-defined inputs + hour snapshots from TheGraph
+ * @param {Object} params - User-defined inputs for LP position
  * @param {number} params.capitalUSD - Actual investment in USD (min $10)
  * @param {number} params.minPrice - Lower price bound (in selected token scale)
  * @param {number} params.maxPrice - Upper price bound (in selected token scale)
  * @param {boolean} params.fullRange - Whether it is a full range position
  * @param {number} params.assumedPrice - Entry price for concentrated positions
  * @param {number} params.selectedTokenIdx - 0 or 1, defines price scale interpretation
- * @param {Object[]} params.hourlyData - TheGraph poolHourData snapshots
  *
  * @returns {{success: boolean, error?: string}} Returns either success state if all inputs valid or failure state if not (with error string)
  */
@@ -18,8 +17,7 @@ export function validateInputs({
   maxPrice,
   fullRange,
   assumedPrice,
-  selectedTokenIdx,
-  hourlyData
+  selectedTokenIdx
 }) {
   if (typeof capitalUSD !== 'number' || isNaN(capitalUSD) || capitalUSD < 10) {
     return { success: false, error: 'Capital must be at least $10' }
@@ -74,16 +72,6 @@ export function validateInputs({
         success: false,
         error: 'Assumed Entry Price must be within the min/max price range.'
       }
-    }
-  }
-
-  if (!hourlyData?.length) {
-    return { success: false, error: 'No hourly data for this pool' }
-  }
-  if (hourlyData.length < 24) {
-    return {
-      success: false,
-      error: 'Insufficient hourly data (min. 24h required)'
     }
   }
 

--- a/src/components/pool-detail/calculator/utils/assessDataQuality.js
+++ b/src/components/pool-detail/calculator/utils/assessDataQuality.js
@@ -15,22 +15,20 @@
  * if (quality === "INSUFFICIENT") showDisclaimer(warnings[0])
  */
 export function assessDataQuality(hourlyData) {
-  // Defensive: Prevents crash if TheGraph query fails or returns null
-  if (!hourlyData || !Array.isArray(hourlyData)) {
+  // Defensive: Prevents crash if TheGraph query fails or returns null or empty array
+  if (!hourlyData || !Array.isArray(hourlyData) || hourlyData.length === 0) {
     return { quality: 'EMPTY', warnings: ['No data provided for analysis.'] }
   }
 
-  const hours = hourlyData.length
-
-  // Time Constants: Explicitly defined for maintainability (hours per period)
-  const ONE_WEEK = 24 * 7 // 168h - Minimum to capture weekly volatility patterns
-  const TWO_WEEKS = 24 * 14 // 336h - Captures bi-weekly rebalancing events
-  const ONE_MONTH = 24 * 30 // 720h - Industry standard for LP projection tools
+  // Measure actual time coverage
+  const firstTs = hourlyData[0].periodStartUnix
+  const lastTs = hourlyData[hourlyData.length - 1].periodStartUnix
+  const spanHours = (lastTs - firstTs) / 3600 + 1
 
   // ===== QUALITY ASSESSMENT TIERS =====
 
   // 1. Critical: Less than 7 days is statistically insignificant for DeFi volume cycles
-  if (hours < ONE_WEEK) {
+  if (spanHours < 168) {
     return {
       quality: 'INSUFFICIENT',
       warnings: [
@@ -40,7 +38,7 @@ export function assessDataQuality(hourlyData) {
   }
 
   // 2. Warning: 7 to 14 days captures weekly cycles but lacks long-term trend stability
-  if (hours < TWO_WEEKS) {
+  if (spanHours < 336) {
     return {
       quality: 'LIMITED',
       warnings: [
@@ -51,7 +49,7 @@ export function assessDataQuality(hourlyData) {
 
   // 3. Robust: 14 to 30 days is the industry standard for short-term LP projections
   // Reference: curve.finance, poolfish.xyz use 14-30d windows for fee APR calculations
-  if (hours < ONE_MONTH) {
+  if (spanHours < 720) {
     return {
       quality: 'RELIABLE',
       warnings: []

--- a/src/components/pool-detail/calculator/utils/simulateRangePerformance.js
+++ b/src/components/pool-detail/calculator/utils/simulateRangePerformance.js
@@ -11,7 +11,7 @@ import { debugLog } from '../../../../utils/logger'
  * Orchestrates historical LP position simulation using hourly on-chain data.
  *
  * Pipeline Architecture (fail-fast stages):
- * 1. Validate inputs (capital, price range, data completeness)
+ * 1. Validate inputs (capital, price range)
  * 2. Assess data quality (EXCELLENT/RELIABLE/LIMITED/INSUFFICIENT)
  * 3. Infer token USD prices from pool TVL
  * 4. Calculate position composition (50/50 vs concentrated)
@@ -32,7 +32,7 @@ import { debugLog } from '../../../../utils/logger'
  * @param {boolean} params.fullRange - If true, simulates V2-style 50/50 position
  * @param {number} params.assumedPrice - Entry price for concentrated positions
  * @param {number} params.selectedTokenIdx - 0 or 1 (defines price interpretation)
- * @param {Object[]} params.hourlyData - TheGraph poolHourData (min 168 hours)
+ * @param {Object[]} params.hourlyData - TheGraph poolHourData (quality assessed by assessDataQuality)
  * @param {Object} params.pool - Pool metadata (TVL, decimals, feeTier)
  *
  * @returns {Object} Simulation result
@@ -63,8 +63,7 @@ export function simulateRangePerformance({
     maxPrice,
     fullRange,
     assumedPrice,
-    selectedTokenIdx,
-    hourlyData
+    selectedTokenIdx
   })
 
   if (!validation.success) return validation
@@ -73,7 +72,7 @@ export function simulateRangePerformance({
   const { quality, warnings: rawWarnings } = assessDataQuality(hourlyData)
   const warnings = Array.isArray(rawWarnings) ? rawWarnings : []
 
-  if (quality === 'INSUFFICIENT') {
+  if (quality === 'EMPTY' || quality === 'INSUFFICIENT') {
     return {
       success: false,
       warning: 'Pool needs 7+ days of data for reliable projections',


### PR DESCRIPTION
## Summary
Fixes false INSUFFICIENT ratings on established pools with sparse hourly snapshots from TheGraph.

## Changes
- **assessDataQuality**: span-based tiers `(lastTs - firstTs) / 3600 + 1`, fencepost fix, extended EMPTY guard
- **validateInputs**: hourlyData checks removed (now owned by assessDataQuality)
- **simulateRangePerformance**: gates on EMPTY + INSUFFICIENT; hourlyData removed from Stage 1 call
- **CalculatorStats**: replaced hasLimitedData with results.warnings (single source of truth)
- **usePoolHourlyData**: default window extended to 30d to match quality tier thresholds

## Follow-up
- #44 – X-axis label density introduced by 30d window

Closes #43 