### PR TITLE
fix(a11y): increase alert-warning and alert-error contrast to WCAG AA

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -39,6 +39,10 @@
   /* NEUTRAL */
   --color-neutral: oklch(0.22 0.04 265);
   --color-neutral-content: oklch(0.70 0.02 265);
+
+  /* ALERTS override (increase contrast to comply with WCAG 4.5:1) */
+  --color-warning-content: oklch(0.25 0.06 36.33);
+  --color-error-content: oklch(0.22 0.08 10.63);
 }
 
 :root {


### PR DESCRIPTION
## fix(a11y): increase alert contrast to meet WCAG AA (4.5:1)

### Problem
`alert-warning` and `alert-error` components failed WCAG AA contrast requirement:
- `alert-warning`: 4.08:1 (text `oklch(0.41 0.112 45.904)` on `oklch(0.75 0.18 80)`)
- `alert-error`: 4.01:1 (text `oklch(0.27 0.105 12.094)` on `oklch(0.63 0.22 15)`)

Affected surfaces: RangeCalculator warnings, login form errors.

### Solution
Override `--color-warning-content` and `--color-error-content` inside the `[data-theme="defi-scout"]` block in `index.css`. Background colors untouched — semantic signal (yellow/red) preserved.

### Result
- `alert-warning`: **7.2:1** ✔️ (WCAG AAA)
- `alert-error`: **5.1:1** ✔️ (WCAG AA)

### Scope
- 1 file changed: `src/index.css`
- 2 CSS custom properties overridden
- No component changes