### PR TITLE
chore: remove scrollIntoView and fix internal table scroll reset

### DIFF
--- a/src/components/pools/PoolsContent.jsx
+++ b/src/components/pools/PoolsContent.jsx
@@ -142,7 +142,7 @@ export function PoolsContent({
         `Showing page ${pageIndex + 1} of ${totalPages}`
       )
     }
-  }, [pageIndex, totalPages])
+  }, [pageIndex, totalPages, filtersKey])
 
   // Derive Set<Object> from visible IDs + paginated data
   // useMemo prevents new Set() reference on every render (would re-trigger useSparklines effect)

--- a/src/components/pools/PoolsContent.jsx
+++ b/src/components/pools/PoolsContent.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect, useRef, useCallback } from 'react'
+import { useMemo, useState, useEffect, useRef } from 'react'
 import { useSearchParams, useNavigate } from 'react-router-dom'
 import { usePrevious } from '../../hooks/usePrevious'
 import { useSparklines } from '../../hooks/useSparklines'
@@ -120,16 +120,6 @@ export function PoolsContent({
     return sortedPools.slice(start, end)
   }, [sortedPools, pageIndex, pageSize])
 
-  const scrollToTableTop = useCallback(() => {
-    if (tableScrollRef.current && tableRef.current) {
-      tableScrollRef.current.scrollTop = 0
-      tableRef.current.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start'
-      })
-    }
-  }, [])
-
   // Reset sparkline cache when page changes (prepares empty Set for IntersectionObserver)
   useEffect(() => {
     setVisiblePoolIds(new Set())
@@ -143,7 +133,7 @@ export function PoolsContent({
       return
     }
 
-    scrollToTableTop()
+    tableScrollRef.current.scrollTop = 0
 
     if (tableRef.current) {
       tableRef.current.setAttribute('aria-live', 'polite')
@@ -152,7 +142,7 @@ export function PoolsContent({
         `Showing page ${pageIndex + 1} of ${totalPages}`
       )
     }
-  }, [pageIndex, totalPages, scrollToTableTop])
+  }, [pageIndex, totalPages])
 
   // Derive Set<Object> from visible IDs + paginated data
   // useMemo prevents new Set() reference on every render (would re-trigger useSparklines effect)


### PR DESCRIPTION
## What
- Removed redundant `scrollIntoView` call from `scrollToTableTop`
- Inlined the remaining single-line scroll reset (dropped `useCallback`)
- Fixed scroll reset not firing on filter change/reset

## Why
`scrollIntoView` became a no-op after the layout changed to a fixed-height table with internal scroll. The internal `scrollTop = 0` was retained but was only triggering on page changes – filter mutations were silently skipped because `filtersKey` was missing from the `useEffect` dependency array.

## Commits
1. chore: remove redundant scrollIntoView from scrollToTableTop
2. fix: reset internal table scroll on filter change

## Testing
- ✔️ Page change -> table scrolls to top
- ✔️ Filter applied on page 1 -> table scrolls to top
- ✔️ Filter reset on page 1 -> table scrolls to top