### PR TITLE
fix(a11y): accessibility pass; modals keyboard navigation and ARIA semantics

### DIFF
--- a/src/components/common/AuthModal.jsx
+++ b/src/components/common/AuthModal.jsx
@@ -144,7 +144,6 @@ export function AuthModal() {
                 id="email"
                 type="email"
                 className="input glass-input mt-1 w-full rounded-xl"
-                aria-label="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 autoComplete="email"
@@ -174,7 +173,6 @@ export function AuthModal() {
                     id="password"
                     type="password"
                     className="input glass-input mt-1 w-full rounded-xl"
-                    aria-label="password"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                     autoComplete={

--- a/src/components/common/AuthModal.jsx
+++ b/src/components/common/AuthModal.jsx
@@ -117,7 +117,7 @@ export function AuthModal() {
         <form onSubmit={handleSubmit}>
           {resetSent ? (
             <>
-              <div className="alert alert-success mt-4 text-sm font-semibold">
+              <div role="alert" className="alert alert-success mt-4 text-sm font-semibold">
                 Check your inbox
               </div>
               <button
@@ -183,7 +183,7 @@ export function AuthModal() {
               )}
 
               {error && (
-                <div className="alert alert-error mt-4 text-sm font-semibold">
+                <div role="alert" className="alert alert-error mt-4 text-sm font-semibold">
                   {error}
                 </div>
               )}

--- a/src/components/common/AuthModal.jsx
+++ b/src/components/common/AuthModal.jsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
+import { useFocusTrap } from './hooks/useFocusTrap'
 import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
@@ -31,6 +32,7 @@ const mapFirebaseError = (code) => ERROR_MAP[code] ?? 'Something went wrong. Ple
 const googleProvider = new GoogleAuthProvider()
 
 export function AuthModal() {
+  const modalRef = useRef(null)
   const [mode, setMode] = useState(MODE.LOGIN)
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -48,6 +50,8 @@ export function AuthModal() {
     setResetSent(false)
     closeAuthModal()
   }
+
+  useFocusTrap(modalRef, isAuthModalOpen, handleClose)
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -97,7 +101,10 @@ export function AuthModal() {
       aria-modal="true"
       aria-labelledby="auth-modal"
     >
-      <div className="modal-box glass-modal max-w-xl rounded-2xl">
+      <div
+        ref={modalRef}
+        className="modal-box glass-modal max-w-xl rounded-2xl"
+      >
         <button
           onClick={handleClose}
           className="btn btn-sm btn-circle btn-glass absolute top-2 right-2 text-sm"

--- a/src/components/common/AuthModal.jsx
+++ b/src/components/common/AuthModal.jsx
@@ -99,8 +99,9 @@ export function AuthModal() {
     >
       <div className="modal-box glass-modal max-w-xl rounded-2xl">
         <button
-          className="btn btn-sm btn-circle btn-glass absolute top-2 right-2 text-sm"
           onClick={handleClose}
+          className="btn btn-sm btn-circle btn-glass absolute top-2 right-2 text-sm"
+          aria-label="Close modal"
         >
           ✕
         </button>

--- a/src/components/common/AuthModal.jsx
+++ b/src/components/common/AuthModal.jsx
@@ -269,8 +269,13 @@ export function AuthModal() {
           )}
         </form>
       </div>
-      <form method="dialog" className="modal-backdrop">
-        <button onClick={handleClose}>close</button>
+      <form
+        method="dialog"
+        onClick={handleClose}
+        className="modal-backdrop"
+        aria-hidden="true"
+      >
+        <button tabIndex="-1">close</button>
       </form>
     </dialog>
   )

--- a/src/components/common/AuthModal.jsx
+++ b/src/components/common/AuthModal.jsx
@@ -92,7 +92,11 @@ export function AuthModal() {
   `
 
   return (
-    <dialog className={`modal ${isAuthModalOpen ? 'modal-open' : ''}`}>
+    <dialog
+      className={`modal ${isAuthModalOpen ? 'modal-open' : ''}`}
+      aria-modal="true"
+      aria-labelledby="auth-modal"
+    >
       <div className="modal-box glass-modal max-w-xl rounded-2xl">
         <button
           className="btn btn-sm btn-circle btn-glass absolute top-2 right-2 text-sm"
@@ -101,7 +105,7 @@ export function AuthModal() {
           ✕
         </button>
 
-        <h3 className="p-4 text-center text-2xl font-bold">
+        <h3 id="auth-modal" className="p-4 text-center text-2xl font-bold">
           {mode === MODE.LOGIN
             ? 'Welcome'
             : mode === MODE.SIGNUP

--- a/src/components/common/AuthModal.jsx
+++ b/src/components/common/AuthModal.jsx
@@ -228,6 +228,7 @@ export function AuthModal() {
                       xmlns="http://www.w3.org/2000/svg"
                       viewBox="0 0 48 48"
                       className="mr-2 h-5 w-5"
+                      aria-hidden="true"
                     >
                       <path
                         fill="#FFC107"

--- a/src/components/common/hooks/useFocusTrap.js
+++ b/src/components/common/hooks/useFocusTrap.js
@@ -1,0 +1,55 @@
+import { useRef, useEffect } from 'react'
+
+const FOCUSABLE_SELECTOR = 'button:not([disabled]), [href], input:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+/**
+ * Traps keyboard focus within a modal. Handles Tab/Shift+Tab cycling.
+ * Escape to close, and restores focus to the trigger element on close.
+ *
+ * @param {React.RefObject<HTMLElement>} modalRef - Ref of container element to trap focus within
+ * @param {boolean} isOpen - Whether the focus trap is currently active
+ * @param {function(): void} onClose - Callback function executed to close the modal (e.g. when pressing 'Escape')
+ */
+export function useFocusTrap(modalRef, isOpen, onClose) {
+  const savedFocusRef = useRef(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      savedFocusRef.current = document.activeElement
+
+      const focusableElements = [...modalRef.current.querySelectorAll(FOCUSABLE_SELECTOR)]
+      const firstElement = focusableElements[0]
+      const lastElement = focusableElements[focusableElements.length - 1]
+
+      if (focusableElements.length) {
+        focusableElements[0].focus()
+      }
+
+      const handleKeyDown = (e) => {
+        if (e.key === 'Escape') onClose()
+
+        if (e.key === 'Tab') {
+          if (e.shiftKey) {
+            if (document.activeElement === firstElement) {
+              lastElement.focus()
+              e.preventDefault()
+            }
+          } else {
+            if (document.activeElement === lastElement) {
+              firstElement.focus()
+              e.preventDefault()
+            }
+          }
+        }
+      }
+      document.addEventListener('keydown', handleKeyDown)
+
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown)
+        savedFocusRef.current?.focus()
+      }
+    }
+  }, [isOpen, onClose, modalRef])
+
+}
+

--- a/src/components/pool-detail/calculator/ILProjectionModal.jsx
+++ b/src/components/pool-detail/calculator/ILProjectionModal.jsx
@@ -48,11 +48,20 @@ export function ILProjectionModal({
   } = useProjectionCalculator(poolData, rangeInputs, results)
 
   return createPortal(
-    <dialog className={`modal ${isOpen ? 'modal-open' : ''}`}>
+    <dialog
+      className={`modal ${isOpen ? 'modal-open' : ''}`}
+      aria-modal="true"
+      aria-labelledby="simulate-position-modal"
+    >
       <div className="modal-box glass-overlay max-w-xl rounded-2xl">
         {/* Header */}
         <div className="mb-6 flex items-center justify-between">
-          <h3 className="text-2xl font-bold">Simulate Position Performance</h3>
+          <h3
+            id="simulate-position-modal"
+            className="text-2xl font-bold"
+          >
+            Simulate Position Performance
+          </h3>
           <button onClick={onClose} className="btn btn-sm btn-circle btn-glass">
             x
           </button>

--- a/src/components/pool-detail/calculator/ILProjectionModal.jsx
+++ b/src/components/pool-detail/calculator/ILProjectionModal.jsx
@@ -1,8 +1,10 @@
+import { useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { PriceInputSection } from './PriceInputSection'
 import { TimeLineControl } from './TimeLineControl'
 import { StrategyComparison } from './StrategyComparison'
 import { useProjectionCalculator } from './hooks/useProjectionCalculator'
+import { useFocusTrap } from '../../common/hooks/useFocusTrap'
 
 /**
  * UI: IL (Impermanent Loss) vs HODL Strategy Simulator
@@ -29,6 +31,9 @@ export function ILProjectionModal({
   rangeInputs,
   results
 }) {
+  const modalRef = useRef(null)
+  useFocusTrap(modalRef, isOpen, onClose)
+
   // Hook Orchestration: Manages complex IL math + debounced recalculation.
   // Simulates AMM rebalancing at each price move, calculates cumulative fees,
   // and compares final LP value vs simple HODL (buy-and-hold).
@@ -53,7 +58,10 @@ export function ILProjectionModal({
       aria-modal="true"
       aria-labelledby="simulate-position-modal"
     >
-      <div className="modal-box glass-overlay max-w-xl rounded-2xl">
+      <div
+        ref={modalRef}
+        className="modal-box glass-overlay max-w-xl rounded-2xl"
+      >
         {/* Header */}
         <div className="mb-6 flex items-center justify-between">
           <h3

--- a/src/components/pool-detail/calculator/ILProjectionModal.jsx
+++ b/src/components/pool-detail/calculator/ILProjectionModal.jsx
@@ -99,8 +99,13 @@ export function ILProjectionModal({
       </div>
 
       {/* Backdrop: Click-outside-to-close */}
-      <form method="dialog" onClick={onClose} className="modal-backdrop">
-        <button>close</button>
+      <form
+        method="dialog"
+        onClick={onClose}
+        className="modal-backdrop"
+        aria-hidden="true"
+      >
+        <button tabIndex="-1">close</button>
       </form>
     </dialog>,
     document.body

--- a/src/components/pool-detail/calculator/ILProjectionModal.jsx
+++ b/src/components/pool-detail/calculator/ILProjectionModal.jsx
@@ -62,7 +62,11 @@ export function ILProjectionModal({
           >
             Simulate Position Performance
           </h3>
-          <button onClick={onClose} className="btn btn-sm btn-circle btn-glass">
+          <button
+            onClick={onClose}
+            className="btn btn-sm btn-circle btn-glass"
+            aria-label="Close modal"
+          >
             x
           </button>
         </div>


### PR DESCRIPTION
## Summary

Addresses WCAG 2.1 violations across `ILProjectionModal` and `AuthModal`. Implements a reusable `useFocusTrap` hook shared by both modals.

## Changes

**ILProjectionModal:**

- Added `aria-modal="true"` and `aria-labelledby` to `<dialog>`
- Added `aria-label="Close modal"` to close button
- Hidden backdrop button from assistive technology (`aria-hidden` + `tabIndex="-1"`)
- Wired `useFocusTrap` for focus management on open/close

**AuthModal:**

- Same ARIA and backdrop fixes as above
- Removed redundant `aria-label` from email/password inputs (`htmlFor`/`id` pairing is sufficient)
- Marked Google SVG as decorative (`aria-hidden="true"`)
- Added `role="alert"` to error and success feedback divs for live region announcement
- Wired `useFocusTrap`

**useFocusTrap (new — src/components/common/hooks/):**

- Reusable hook: saves trigger element, traps Tab/Shift+Tab, handles Escape, restores focus on close

## Testing

- ✔️ Keyboard navigation verified manually (Tab, Shift+Tab, Escape) on both modals
- ✔️ Focus returns to trigger element on close