### PR TITLE
fix: eliminate CLS on PoolDetail page (#fix/cls-pool-detail)

### DIFF
--- a/src/components/pool-detail/PoolDetail.jsx
+++ b/src/components/pool-detail/PoolDetail.jsx
@@ -57,8 +57,8 @@ const BlockExplorerIcon = () => (
  */
 export function PoolDetail() {
   const { pool, history, ethPriceUSD } = useLoaderData()
-  const { hourlyData, isLoading, fetchError } = usePoolHourlyData(pool.id)
-  const { tickData, fetchError: tickError } = usePoolTickData(
+  const { hourlyData, isLoading: hourlyIsLoading, fetchError } = usePoolHourlyData(pool.id)
+  const { tickData, isLoading: tickIsLoading, fetchError: tickError } = usePoolTickData(
     pool.id,
     pool.tick,
     pool.feeTier
@@ -338,7 +338,7 @@ export function PoolDetail() {
             inputs={rangeInputs}
             onInputsChange={setRangeInputs}
             hourlyData={hourlyData}
-            isLoading={isLoading}
+            hourlyIsLoading={hourlyIsLoading}
             fetchError={fetchError}
             ethPriceUSD={ethPriceUSD}
           />
@@ -358,6 +358,8 @@ export function PoolDetail() {
             currentPrice={currentPrice}
             tickData={tickData}
             tickError={tickError}
+            hourlyIsLoading={hourlyIsLoading}
+            tickIsLoading={tickIsLoading}
           />
         </div>
         <div className="mb-4 md:hidden">

--- a/src/components/pool-detail/charts/ChartSkeleton.jsx
+++ b/src/components/pool-detail/charts/ChartSkeleton.jsx
@@ -1,0 +1,8 @@
+export function ChartSkeleton() {
+  return (
+    <div className="rounded-2xl glass-surface p-4 animate-pulse">
+      <div className="h-6 w-48 bg-base-300 rounded-xl mb-4"/>
+      <div className="h-[300px] bg-base-300/50 rounded-xl"/>
+    </div>
+  )
+}

--- a/src/components/pool-detail/charts/PoolCharts.jsx
+++ b/src/components/pool-detail/charts/PoolCharts.jsx
@@ -1,6 +1,7 @@
 import { LiquidityChart } from './LiquidityChart'
 import { PriceChart } from './PriceChart'
 import { TVLVolumeChart } from './TVLVolumeChart'
+import { ChartSkeleton } from './ChartSkeleton'
 
 /**
  * UI: Pool Analytics Dashboard.
@@ -23,7 +24,9 @@ export function PoolCharts({
   rangeInputs,
   currentPrice,
   tickData,
-  tickError
+  tickError,
+  hourlyIsLoading,
+  tickIsLoading
 }) {
   // UI/UX: Empty state
   if (!history?.length) {
@@ -36,23 +39,30 @@ export function PoolCharts({
 
   return (
     <div className="grid grid-cols-1 gap-4">
-      <LiquidityChart
-        selectedTokenIdx={selectedTokenIdx}
-        tokenSymbols={tokenSymbols}
-        token0Decimals={pool.token0.decimals}
-        token1Decimals={pool.token1.decimals}
-        rangeInputs={rangeInputs}
-        currentPrice={currentPrice}
-        tickData={tickData}
-        tickError={tickError}
-      />
-      <PriceChart
-        hourlyData={hourlyData}
-        selectedTokenIdx={selectedTokenIdx}
-        tokenSymbols={tokenSymbols}
-        rangeInputs={rangeInputs}
-        currentPrice={currentPrice}
-      />
+      {tickIsLoading
+        ? <ChartSkeleton />
+        : <LiquidityChart
+            selectedTokenIdx={selectedTokenIdx}
+            tokenSymbols={tokenSymbols}
+            token0Decimals={pool.token0.decimals}
+            token1Decimals={pool.token1.decimals}
+            rangeInputs={rangeInputs}
+            currentPrice={currentPrice}
+            tickData={tickData}
+            tickError={tickError}
+            isLoading={tickIsLoading}
+          />
+      }
+      {hourlyIsLoading
+        ? <ChartSkeleton/>
+        : <PriceChart
+            hourlyData={hourlyData}
+            selectedTokenIdx={selectedTokenIdx}
+            tokenSymbols={tokenSymbols}
+            rangeInputs={rangeInputs}
+            currentPrice={currentPrice}
+          />
+      }
       <TVLVolumeChart history={history} />
     </div>
   )


### PR DESCRIPTION
## Problem
Three layout shifts occurred on `PoolDetail` mount:
- `LiquidityChart` and `PriceChart` collapsed to zero height while their client-side data loaded, then jumped to full height on arrival
- `CalculatorStats` grew vertically when the action button appeared after a successful simulation result

## Solution
Added skeleton loading states to occupy layout space before data arrives.

## Changes
- `ChartSkeleton.jsx` – new component mirroring the card structure of both charts (glass-surface wrapper, title bar placeholder, 300px chart area)
- `PoolCharts.jsx` – independent loading signals per chart: `tickIsLoading` gates `LiquidityChart`, `hourlyIsLoading` gates `PriceChart`
- `PoolDetail.jsx` – destructuring aliases expose separate `isLoading` flags from `usePoolHourlyData` and `usePoolTickData`
- `CalculatorStats.jsx` – disabled button rendered in all non-success states to hold layout space consistently

## What was intentionally excluded
`TVLVolumeChart`: data comes from the blocking loader, available on first render – no skeleton needed.