### PR TITLE
fix: prevent focus-trap effect from re-running on every keystroke

### DIFF
--- a/src/components/common/hooks/useFocusTrap.js
+++ b/src/components/common/hooks/useFocusTrap.js
@@ -12,6 +12,11 @@ const FOCUSABLE_SELECTOR = 'button:not([disabled]), [href], input:not([disabled]
  */
 export function useFocusTrap(modalRef, isOpen, onClose) {
   const savedFocusRef = useRef(null)
+  const onCloseRef = useRef(onClose)
+
+  useEffect(() => {
+    onCloseRef.current = onClose
+  })
 
   useEffect(() => {
     if (isOpen) {
@@ -26,7 +31,7 @@ export function useFocusTrap(modalRef, isOpen, onClose) {
       }
 
       const handleKeyDown = (e) => {
-        if (e.key === 'Escape') onClose()
+        if (e.key === 'Escape') onCloseRef.current()
 
         if (e.key === 'Tab') {
           if (e.shiftKey) {
@@ -49,7 +54,6 @@ export function useFocusTrap(modalRef, isOpen, onClose) {
         savedFocusRef.current?.focus()
       }
     }
-  }, [isOpen, onClose, modalRef])
-
+  }, [isOpen, modalRef])
 }
 


### PR DESCRIPTION
## Problem
Opening AuthModal and typing in any input field caused the close button to steal focus on every keystroke, making the form unusable with keyboard.

## Root Cause
`handleClose` in AuthModal was recreated on every render (no useCallback). This caused `onClose` to have a new identity on each keystroke, triggering the useFocusTrap effect to re-run while the modal was open, which called `focusableElements[0].focus()` – the close button.

## Fix
Introduced a ref pattern inside `useFocusTrap` to decouple the callback from the effect's dependency array:
- `onCloseRef` stores the latest `onClose` via a no-dep sync effect
- Main trap effect now depends only on `[isOpen, modalRef]`
- Escape key calls `onCloseRef.current()` instead of `onClose` directly

The hook is now resilient to unstable callbacks from any caller.

## Testing
- Opened AuthModal → typed in email/password fields → close button no longer steals focus
- Pressed Escape → modal closes correctly
- Tab/Shift+Tab cycling → still works as expected